### PR TITLE
Upgrade to Spring Boot 4.0.2 with Flyway migrations

### DIFF
--- a/.claude/skills/flyway-migration/SKILL.md
+++ b/.claude/skills/flyway-migration/SKILL.md
@@ -1,0 +1,22 @@
+# create-flyway-migration
+
+Creates Flyway migration files following project conventions.
+
+## Usage
+
+```bash
+./scripts/genDDLFile.sh "description"
+```
+
+Examples:
+- `./scripts/genDDLFile.sh "create user table"`
+- `./scripts/genDDLFile.sh "add email column to user"`
+- `./scripts/genDDLFile.sh "dml add initial admin users"`
+
+### File naming
+- Format: `V{YYYYMMDDHHmmss}__{description}.sql`
+- DML files: prefix description with `dml_`
+
+### Indexes
+- Format: `INDEX idx_{column_name} (column_name)`
+- Define inline in CREATE TABLE

--- a/apps/api/build.gradle.kts
+++ b/apps/api/build.gradle.kts
@@ -1,9 +1,9 @@
 plugins {
-	kotlin("jvm") version "1.9.25"
-	kotlin("plugin.spring") version "1.9.25"
-	id("org.springframework.boot") version "3.5.10"
+	kotlin("jvm") version "2.2.0"
+	kotlin("plugin.spring") version "2.2.0"
+	id("org.springframework.boot") version "4.0.2"
 	id("io.spring.dependency-management") version "1.1.7"
-	kotlin("plugin.jpa") version "1.9.25"
+	kotlin("plugin.jpa") version "2.2.0"
 }
 
 group = "com.briefy"
@@ -21,7 +21,7 @@ repositories {
 	maven { url = uri("https://repo.spring.io/milestone") }
 }
 
-extra["springAiVersion"] = "1.0.0"
+extra["springAiVersion"] = "2.0.0-M2"
 
 dependencyManagement {
 	imports {
@@ -35,10 +35,10 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-	implementation("org.flywaydb:flyway-core")
+	implementation("org.springframework.boot:spring-boot-starter-flyway")
 	implementation("org.flywaydb:flyway-database-postgresql")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
-	implementation("org.springframework.ai:spring-ai-openai-spring-boot-starter")
+	implementation("org.springframework.ai:spring-ai-openai")
 	runtimeOnly("org.postgresql:postgresql")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/apps/api/src/main/resources/application.yml
+++ b/apps/api/src/main/resources/application.yml
@@ -14,13 +14,15 @@ spring:
 
   flyway:
     enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
 
   ai:
     openai:
       api-key: ${LLM_API_KEY:}
 
 server:
-  port: 8080
+  port: ${SERVER_PORT:8081}
 
 management:
   endpoints:

--- a/apps/api/src/main/resources/db/migration/V20260204143150__initial_schema.sql
+++ b/apps/api/src/main/resources/db/migration/V20260204143150__initial_schema.sql
@@ -1,0 +1,30 @@
+-- Initial schema for Briefy
+-- Creates placeholder tables for all domain entities
+
+CREATE TABLE sources (
+    id UUID PRIMARY KEY
+);
+
+CREATE TABLE briefings (
+    id UUID PRIMARY KEY
+);
+
+CREATE TABLE takeaways (
+    id UUID PRIMARY KEY
+);
+
+CREATE TABLE topics (
+    id UUID PRIMARY KEY
+);
+
+CREATE TABLE topic_links (
+    id UUID PRIMARY KEY
+);
+
+CREATE TABLE enrichments (
+    id UUID PRIMARY KEY
+);
+
+CREATE TABLE recalls (
+    id UUID PRIMARY KEY
+);

--- a/scripts/genDDLFile.sh
+++ b/scripts/genDDLFile.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Check if a description was provided
+if [ $# -eq 0 ]; then
+    echo "Usage: ./genDDLFile.sh \"your migration description\""
+    exit 1
+fi
+
+# Configuration
+MIGRATION_DIR="apps/api/src/main/resources/db/migration"
+DESCRIPTION=$(echo "$1" | tr '[:upper:]' '[:lower:]' | tr ' ' '_' | sed 's/["\x27]//g')
+TIMESTAMP=$(date +%Y%m%d%H%M%S)
+FILENAME="V${TIMESTAMP}__${DESCRIPTION}.sql"
+
+# Create migrations directory if it doesn't exist
+mkdir -p "$MIGRATION_DIR"
+
+# Create the migration file
+FILEPATH="$MIGRATION_DIR/$FILENAME"
+touch "$FILEPATH"
+
+echo "-- Migration file created: $FILENAME"
+echo "-- Description: $1"
+echo "-- Path: $FILEPATH"
+
+# Optional: Open the file in the default editor
+# Uncomment the line for your preferred editor
+# code "$FILEPATH"  # VS Code
+# idea "$FILEPATH"  # IntelliJ IDEA


### PR DESCRIPTION
- Upgrade Spring Boot 3.5.10 → 4.0.2
- Upgrade Kotlin 1.9.25 → 2.2.0
- Upgrade Spring AI 1.0.0 → 2.0.0-M2
- Replace flyway-core with spring-boot-starter-flyway (required by Boot 4)
- Rename spring-ai-openai-spring-boot-starter → spring-ai-openai
- Add Flyway configuration (locations, baseline-on-migrate)
- Add initial schema migration for placeholder entities
- Add genDDLFile.sh script for creating migrations
- Change default server port to 8081