### PR TITLE
Fix IPv6 connectivity errors for ZhiPu and Gemini on Railway

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -15,4 +15,4 @@ RUN apt-get update && \
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Djava.net.preferIPv4Stack=true", "-jar", "app.jar"]


### PR DESCRIPTION
## Summary
- Force IPv4 stack in JVM entrypoint to prevent Railway's injected `JAVA_TOOL_OPTIONS: -Djava.net.preferIPv6Addresses=true` from routing external API calls through unreachable IPv6 addresses
- Fixes connection failures for ZhiPu (`api.z.ai`) and Gemini (`generativelanguage.googleapis.com`) that caused 25+ minute retry loops

## Test plan
- [ ] Deploy to Railway: `railway up apps/api --service briefy-api --path-as-root --detach`
- [ ] Verify `JAVA_TOOL_OPTIONS` warning still appears in logs but connections succeed
- [ ] Trigger an LLM call (topic suggestions or formatting) and confirm no IPv6 connection errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force IPv4 in the API JVM entrypoint to prevent Railway’s IPv6 preference from breaking outbound calls. Fixes connection failures and long retry loops for ZhiPu (api.z.ai) and Gemini (generativelanguage.googleapis.com).

- **Bug Fixes**
  - Set -Djava.net.preferIPv4Stack=true in the Docker ENTRYPOINT to override JAVA_TOOL_OPTIONS (-Djava.net.preferIPv6Addresses=true).

<sup>Written for commit 322000cae217a6a8e6a76c9525f4ba301315ab5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

