### PR TITLE
fix: add current date to all AI system prompts

### DIFF
--- a/apps/api/src/main/kotlin/com/briefy/api/application/briefing/AiBriefingPlanGenerator.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/application/briefing/AiBriefingPlanGenerator.kt
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 @Component
 class AiBriefingPlanGenerator(
@@ -149,7 +150,7 @@ class AiBriefingPlanGenerator(
         private const val MAX_PERSONA_NAME_CHARS = 120
         private val FENCED_JSON_REGEX = Regex("```(?:json)?\\s*(\\{[\\s\\S]*\\})\\s*```", RegexOption.IGNORE_CASE)
         private fun buildSystemPrompt(): String {
-            val today = LocalDate.now().format(DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy"))
+            val today = LocalDate.now().format(DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy", Locale.ENGLISH))
             return """
 You are a planning engine for briefing generation.
 Today's date is $today.

--- a/apps/api/src/main/kotlin/com/briefy/api/application/briefing/AiBriefingPlanGenerator.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/application/briefing/AiBriefingPlanGenerator.kt
@@ -6,6 +6,8 @@ import com.briefy.api.infrastructure.ai.AiAdapter
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 @Component
 class AiBriefingPlanGenerator(
@@ -28,7 +30,7 @@ class AiBriefingPlanGenerator(
             provider = provider,
             model = model,
             prompt = buildPrompt(enrichmentIntent, sources, personas),
-            systemPrompt = SYSTEM_PROMPT,
+            systemPrompt = buildSystemPrompt(),
             useCase = "briefing_planning"
         )
 
@@ -146,11 +148,15 @@ class AiBriefingPlanGenerator(
         private const val MAX_TASK_CHARS = 600
         private const val MAX_PERSONA_NAME_CHARS = 120
         private val FENCED_JSON_REGEX = Regex("```(?:json)?\\s*(\\{[\\s\\S]*\\})\\s*```", RegexOption.IGNORE_CASE)
-        private const val SYSTEM_PROMPT = """
+        private fun buildSystemPrompt(): String {
+            val today = LocalDate.now().format(DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy"))
+            return """
 You are a planning engine for briefing generation.
+Today's date is $today.
 Return strict JSON only with this shape:
 {"steps":[{"personaName":"string","task":"string"}]}
 No markdown, no commentary.
 """
+        }
     }
 }

--- a/apps/api/src/main/kotlin/com/briefy/api/application/briefing/AiSubagentExecutionRunner.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/application/briefing/AiSubagentExecutionRunner.kt
@@ -13,6 +13,8 @@ import com.briefy.api.infrastructure.ai.RetryableToolExecutionException
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
 import org.springframework.ai.tool.ToolCallback
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import org.springframework.ai.tool.function.FunctionToolCallback
 import java.util.UUID
 import java.util.function.Function
@@ -178,7 +180,10 @@ class AiSubagentExecutionRunner(
     private fun buildSystemPrompt(context: SubagentExecutionContext): String {
         val availableTools = buildAvailableTools()
         val rules = buildToolUsageRules()
+        val today = LocalDate.now().format(DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy"))
         return """You are "${context.personaName}", an AI research persona working on a briefing.
+
+Today's date is $today.
 
 Your task is to investigate a specific angle and produce a curated analysis backed by evidence.
 

--- a/apps/api/src/main/kotlin/com/briefy/api/application/briefing/AiSubagentExecutionRunner.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/application/briefing/AiSubagentExecutionRunner.kt
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.ai.tool.ToolCallback
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 import org.springframework.ai.tool.function.FunctionToolCallback
 import java.util.UUID
 import java.util.function.Function
@@ -180,7 +181,7 @@ class AiSubagentExecutionRunner(
     private fun buildSystemPrompt(context: SubagentExecutionContext): String {
         val availableTools = buildAvailableTools()
         val rules = buildToolUsageRules()
-        val today = LocalDate.now().format(DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy"))
+        val today = LocalDate.now().format(DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy", Locale.ENGLISH))
         return """You are "${context.personaName}", an AI research persona working on a briefing.
 
 Today's date is $today.

--- a/apps/api/src/main/kotlin/com/briefy/api/application/briefing/AiSynthesisExecutionRunner.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/application/briefing/AiSynthesisExecutionRunner.kt
@@ -3,6 +3,8 @@ package com.briefy.api.application.briefing
 import com.briefy.api.infrastructure.ai.AiAdapter
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 class AiSynthesisExecutionRunner(
     private val aiAdapter: AiAdapter,
@@ -44,7 +46,10 @@ class AiSynthesisExecutionRunner(
     }
 
     private fun buildSystemPrompt(): String {
+        val today = LocalDate.now().format(DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy"))
         return """You synthesize multi-persona research into one cohesive briefing.
+
+Today's date is $today.
 
 Requirements:
 1. Resolve disagreements explicitly; do not hide conflicts.

--- a/apps/api/src/main/kotlin/com/briefy/api/application/briefing/AiSynthesisExecutionRunner.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/application/briefing/AiSynthesisExecutionRunner.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 class AiSynthesisExecutionRunner(
     private val aiAdapter: AiAdapter,
@@ -46,7 +47,7 @@ class AiSynthesisExecutionRunner(
     }
 
     private fun buildSystemPrompt(): String {
-        val today = LocalDate.now().format(DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy"))
+        val today = LocalDate.now().format(DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy", Locale.ENGLISH))
         return """You synthesize multi-persona research into one cohesive briefing.
 
 Today's date is $today.

--- a/apps/api/src/main/kotlin/com/briefy/api/application/chat/ChatService.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/application/chat/ChatService.kt
@@ -39,6 +39,8 @@ import reactor.core.scheduler.Schedulers
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
 import java.time.Instant
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 import java.util.function.Function
 
@@ -416,8 +418,10 @@ class ChatService(
     }
 
     private fun buildSystemPrompt(references: List<ResolvedReference>): String {
+        val today = LocalDate.now().format(DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy"))
         val instructions = buildString {
             appendLine("You are Briefy, a knowledge assistant for a personal research and reading platform.")
+            appendLine("Today's date is $today.")
             appendLine("The user saves sources and organizes them into topics inside Briefy.")
             appendLine("Answer clearly and directly.")
             appendLine("When the user asks about their library, topics, sources, reading habits, or interests, use your tools to look up real data before answering. Never ask the user for permission to use a tool — just use it.")

--- a/apps/api/src/main/kotlin/com/briefy/api/application/chat/ChatService.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/application/chat/ChatService.kt
@@ -41,6 +41,7 @@ import org.springframework.security.core.context.SecurityContextHolder
 import java.time.Instant
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 import java.util.UUID
 import java.util.function.Function
 
@@ -418,7 +419,7 @@ class ChatService(
     }
 
     private fun buildSystemPrompt(references: List<ResolvedReference>): String {
-        val today = LocalDate.now().format(DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy"))
+        val today = LocalDate.now().format(DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy", Locale.ENGLISH))
         val instructions = buildString {
             appendLine("You are Briefy, a knowledge assistant for a personal research and reading platform.")
             appendLine("Today's date is $today.")


### PR DESCRIPTION
## Summary
- Adds a dynamically formatted current date (`EEEE, MMMM d, yyyy`) to all AI system prompts: briefing planning, subagent research, synthesis, and chat
- Fixes models defaulting to their training data cutoff (late 2024) when reasoning about temporal context — e.g. a briefing generated today saying "real-time market data as of late 2024"

## Test plan
- [x] `./gradlew compileKotlin` passes
- [x] `./gradlew test` passes
- [ ] Generate a briefing and verify the content references the correct current date

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the current date to all system prompts so models use the correct time context across briefing planning, subagent research, synthesis, and chat. Also pin the date formatter to English to avoid non-English output.

- **Bug Fixes**
  - Inserted "Today's date is {EEEE, MMMM d, yyyy}" into each system prompt using `LocalDate` and `DateTimeFormatter` with `Locale.ENGLISH`.
  - Applied across planning, subagent execution, synthesis, and chat flows.

<sup>Written for commit 8b778060e73028e005f3b195f4ed92372c57996d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

