### PR TITLE
Strip markdown from briefing preview card snippet

### DIFF
--- a/apps/api/src/main/kotlin/com/briefy/api/application/briefing/BriefingService.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/application/briefing/BriefingService.kt
@@ -121,7 +121,7 @@ class BriefingService(
                 enrichmentIntent = briefing.enrichmentIntent.name.lowercase(),
                 title = briefing.title,
                 sourceCount = briefingSourceRepository.countByBriefingId(briefing.id),
-                contentSnippet = briefing.contentMarkdown?.take(200),
+                contentSnippet = briefing.contentMarkdown?.let { stripMarkdown(it).take(200) },
                 createdAt = briefing.createdAt,
                 updatedAt = briefing.updatedAt
             )
@@ -376,5 +376,24 @@ class BriefingService(
             return null
         }
         return runCatching { objectMapper.readValue(json, typeReference) }.getOrNull()
+    }
+
+    private fun stripMarkdown(markdown: String): String {
+        return markdown
+            .replace(Regex("^#{1,6}\\s+.*$", RegexOption.MULTILINE), "")
+            .replace(Regex("\\*\\*(.+?)\\*\\*"), "$1")
+            .replace(Regex("__(.+?)__"), "$1")
+            .replace(Regex("\\*(.+?)\\*"), "$1")
+            .replace(Regex("_(.+?)_"), "$1")
+            .replace(Regex("~~(.+?)~~"), "$1")
+            .replace(Regex("!\\[.*?]\\(.*?\\)"), "")
+            .replace(Regex("\\[(.+?)]\\(.*?\\)"), "$1")
+            .replace(Regex("^>\\s?", RegexOption.MULTILINE), "")
+            .replace(Regex("^[-*+]\\s+", RegexOption.MULTILINE), "")
+            .replace(Regex("^\\d+\\.\\s+", RegexOption.MULTILINE), "")
+            .replace(Regex("`{1,3}"), "")
+            .replace(Regex("\\n{2,}"), " ")
+            .replace(Regex("\\n"), " ")
+            .trim()
     }
 }


### PR DESCRIPTION
## Summary
- The `contentSnippet` in the briefing preview card was displaying raw markdown (headings, bold markers, links, etc.)
- Added `stripMarkdown` to `BriefingService` that strips markdown syntax and removes heading lines entirely before truncating to 200 characters
- The preview card now shows clean plain text

## Test plan
- [ ] Verify briefing preview cards no longer show `#`, `**`, `[]()`  or other markdown syntax
- [ ] Verify heading text is excluded from the snippet (only body content appears)
- [ ] Verify snippet still truncates at 200 characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes briefing preview snippets by stripping markdown and removing headings before truncation. Preview cards now show clean, readable text.

- **Bug Fixes**
  - Added stripMarkdown in BriefingService to remove headings, formatting marks, links/images, blockquotes, lists, and code markers; normalizes whitespace.
  - Updated snippet generation to strip first, then truncate to 200 characters.

<sup>Written for commit a7a57f21c2993686610cf8902def908b33adc392. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

