### PR TITLE
feat: OAuth 2.0 authorization server for MCP connector flow

### DIFF
--- a/apps/api/src/main/kotlin/com/briefy/api/api/GlobalExceptionHandler.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/api/GlobalExceptionHandler.kt
@@ -24,6 +24,7 @@ import com.briefy.api.application.topic.TopicLinkNotFoundException
 import com.briefy.api.application.topic.TopicNotFoundException
 import com.briefy.api.application.oauthserver.OAuthClientNotFoundException
 import com.briefy.api.application.oauthserver.OAuthInvalidGrantException
+import com.briefy.api.application.oauthserver.OAuthInvalidRequestException
 import com.briefy.api.application.oauthserver.OAuthInvalidRedirectUriException
 import com.briefy.api.application.oauthserver.OAuthInvalidScopeException
 import com.briefy.api.application.oauthserver.OAuthInvalidTokenException
@@ -405,6 +406,12 @@ class GlobalExceptionHandler {
     fun handleOAuthInvalidRedirectUri(ex: OAuthInvalidRedirectUriException): ResponseEntity<ErrorResponse> {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(ErrorResponse(HttpStatus.BAD_REQUEST.value(), "invalid_request", ex.message ?: "Invalid redirect_uri"))
+    }
+
+    @ExceptionHandler(OAuthInvalidRequestException::class)
+    fun handleOAuthInvalidRequest(ex: OAuthInvalidRequestException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(HttpStatus.BAD_REQUEST.value(), "invalid_request", ex.message ?: "Invalid request"))
     }
 
     @ExceptionHandler(OAuthInvalidScopeException::class)

--- a/apps/api/src/main/kotlin/com/briefy/api/api/GlobalExceptionHandler.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/api/GlobalExceptionHandler.kt
@@ -22,6 +22,14 @@ import com.briefy.api.application.topic.TopicAlreadyExistsException
 import com.briefy.api.application.topic.TopicAlreadyLinkedToSourceException
 import com.briefy.api.application.topic.TopicLinkNotFoundException
 import com.briefy.api.application.topic.TopicNotFoundException
+import com.briefy.api.application.oauthserver.OAuthClientNotFoundException
+import com.briefy.api.application.oauthserver.OAuthInvalidGrantException
+import com.briefy.api.application.oauthserver.OAuthInvalidRedirectUriException
+import com.briefy.api.application.oauthserver.OAuthInvalidScopeException
+import com.briefy.api.application.oauthserver.OAuthInvalidTokenException
+import com.briefy.api.application.oauthserver.OAuthPkceRequiredException
+import com.briefy.api.application.oauthserver.OAuthPkceVerificationException
+import com.briefy.api.application.oauthserver.OAuthUnsupportedGrantTypeException
 import com.briefy.api.infrastructure.extraction.ExtractionProviderException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -385,6 +393,54 @@ class GlobalExceptionHandler {
                 error = "Not Found",
                 message = ex.message ?: "Share link audio is not available"
             ))
+    }
+
+    @ExceptionHandler(OAuthClientNotFoundException::class)
+    fun handleOAuthClientNotFound(ex: OAuthClientNotFoundException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(HttpStatus.BAD_REQUEST.value(), "invalid_client", ex.message ?: "Unknown client"))
+    }
+
+    @ExceptionHandler(OAuthInvalidRedirectUriException::class)
+    fun handleOAuthInvalidRedirectUri(ex: OAuthInvalidRedirectUriException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(HttpStatus.BAD_REQUEST.value(), "invalid_request", ex.message ?: "Invalid redirect_uri"))
+    }
+
+    @ExceptionHandler(OAuthInvalidScopeException::class)
+    fun handleOAuthInvalidScope(ex: OAuthInvalidScopeException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(HttpStatus.BAD_REQUEST.value(), "invalid_scope", ex.message ?: "Invalid scope"))
+    }
+
+    @ExceptionHandler(OAuthInvalidGrantException::class)
+    fun handleOAuthInvalidGrant(ex: OAuthInvalidGrantException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(HttpStatus.BAD_REQUEST.value(), "invalid_grant", ex.message ?: "Invalid grant"))
+    }
+
+    @ExceptionHandler(OAuthInvalidTokenException::class)
+    fun handleOAuthInvalidToken(ex: OAuthInvalidTokenException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+            .body(ErrorResponse(HttpStatus.UNAUTHORIZED.value(), "invalid_token", ex.message ?: "Invalid token"))
+    }
+
+    @ExceptionHandler(OAuthPkceRequiredException::class)
+    fun handleOAuthPkceRequired(ex: OAuthPkceRequiredException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(HttpStatus.BAD_REQUEST.value(), "invalid_request", ex.message ?: "PKCE required"))
+    }
+
+    @ExceptionHandler(OAuthPkceVerificationException::class)
+    fun handleOAuthPkceVerification(ex: OAuthPkceVerificationException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(HttpStatus.BAD_REQUEST.value(), "invalid_grant", ex.message ?: "PKCE verification failed"))
+    }
+
+    @ExceptionHandler(OAuthUnsupportedGrantTypeException::class)
+    fun handleOAuthUnsupportedGrantType(ex: OAuthUnsupportedGrantTypeException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(HttpStatus.BAD_REQUEST.value(), "unsupported_grant_type", ex.message ?: "Unsupported grant type"))
     }
 
     @ExceptionHandler(Exception::class)

--- a/apps/api/src/main/kotlin/com/briefy/api/api/oauth/OAuthAuthorizeController.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/api/oauth/OAuthAuthorizeController.kt
@@ -1,0 +1,232 @@
+package com.briefy.api.api.oauth
+
+import com.briefy.api.application.oauthserver.OAuthClientNotFoundException
+import com.briefy.api.application.oauthserver.OAuthInvalidRedirectUriException
+import com.briefy.api.application.oauthserver.OAuthServerService
+import com.briefy.api.infrastructure.security.AuthenticatedUser
+import jakarta.servlet.http.HttpServletRequest
+import org.slf4j.LoggerFactory
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.net.URI
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+@RestController
+@RequestMapping("/oauth/authorize")
+class OAuthAuthorizeController(
+    private val oauthServerService: OAuthServerService
+) {
+    private val logger = LoggerFactory.getLogger(OAuthAuthorizeController::class.java)
+
+    @GetMapping
+    fun showConsent(
+        @RequestParam("client_id") clientId: String,
+        @RequestParam("redirect_uri") redirectUri: String,
+        @RequestParam("scope") scope: String,
+        @RequestParam("response_type") responseType: String,
+        @RequestParam("state", required = false) state: String?,
+        @RequestParam("code_challenge") codeChallenge: String,
+        @RequestParam("code_challenge_method") codeChallengeMethod: String,
+        request: HttpServletRequest
+    ): ResponseEntity<String> {
+        if (responseType != "code") {
+            return errorPage("unsupported_response_type", "Only response_type=code is supported")
+        }
+
+        val principal = currentUser()
+        if (principal == null) {
+            val loginUrl = "/login?next=${encode(request.requestURI + "?" + request.queryString)}"
+            return ResponseEntity.status(302).location(URI.create(loginUrl)).build()
+        }
+
+        val context = try {
+            oauthServerService.validateAuthorizationRequest(clientId, redirectUri, scope, codeChallenge, codeChallengeMethod)
+        } catch (e: OAuthClientNotFoundException) {
+            return errorPage("invalid_client", "Unknown client")
+        } catch (e: OAuthInvalidRedirectUriException) {
+            return errorPage("invalid_request", "Redirect URI not allowed")
+        } catch (e: Exception) {
+            return errorPage("invalid_request", e.message ?: "Invalid request")
+        }
+
+        val html = buildConsentHtml(
+            clientName = context.client.name,
+            scopes = context.scopes,
+            clientId = clientId,
+            redirectUri = redirectUri,
+            scope = scope,
+            state = state,
+            codeChallenge = codeChallenge,
+            codeChallengeMethod = codeChallengeMethod
+        )
+        return ResponseEntity.ok().contentType(MediaType.TEXT_HTML).body(html)
+    }
+
+    @PostMapping
+    fun handleConsent(
+        @RequestParam("client_id") clientId: String,
+        @RequestParam("redirect_uri") redirectUri: String,
+        @RequestParam("scope") scope: String,
+        @RequestParam("state", required = false) state: String?,
+        @RequestParam("code_challenge") codeChallenge: String,
+        @RequestParam("code_challenge_method") codeChallengeMethod: String,
+        @RequestParam("approved", defaultValue = "false") approved: Boolean
+    ): ResponseEntity<Void> {
+        val principal = currentUser()
+            ?: return ResponseEntity.status(302).location(URI.create("/login")).build()
+
+        if (!approved) {
+            val deniedUri = buildRedirectUri(redirectUri, null, "access_denied", "User denied access", state)
+            return ResponseEntity.status(302).location(URI.create(deniedUri)).build()
+        }
+
+        val context = try {
+            oauthServerService.validateAuthorizationRequest(clientId, redirectUri, scope, codeChallenge, codeChallengeMethod)
+        } catch (e: OAuthClientNotFoundException) {
+            val errorUri = buildRedirectUri(redirectUri, null, "invalid_client", "Unknown client", state)
+            return ResponseEntity.status(302).location(URI.create(errorUri)).build()
+        } catch (e: Exception) {
+            val errorUri = buildRedirectUri(redirectUri, null, "invalid_request", e.message ?: "Invalid request", state)
+            return ResponseEntity.status(302).location(URI.create(errorUri)).build()
+        }
+
+        val code = oauthServerService.issueAuthorizationCode(
+            clientId = clientId,
+            userId = principal.id,
+            redirectUri = redirectUri,
+            scopes = context.scopes,
+            codeChallenge = codeChallenge
+        )
+
+        logger.info("[oauth] Consent granted clientId={} userId={}", clientId, principal.id)
+        val successUri = buildRedirectUri(redirectUri, code, null, null, state)
+        return ResponseEntity.status(302).location(URI.create(successUri)).build()
+    }
+
+    private fun currentUser(): AuthenticatedUser? {
+        val auth = SecurityContextHolder.getContext().authentication ?: return null
+        return auth.principal as? AuthenticatedUser
+    }
+
+    private fun buildRedirectUri(
+        base: String,
+        code: String?,
+        error: String?,
+        errorDescription: String?,
+        state: String?
+    ): String {
+        val params = mutableListOf<String>()
+        if (code != null) params.add("code=${encode(code)}")
+        if (error != null) params.add("error=${encode(error)}")
+        if (errorDescription != null) params.add("error_description=${encode(errorDescription)}")
+        if (state != null) params.add("state=${encode(state)}")
+        return if (params.isEmpty()) base else "$base?${params.joinToString("&")}"
+    }
+
+    private fun errorPage(error: String, description: String): ResponseEntity<String> {
+        val html = """
+            <!DOCTYPE html>
+            <html lang="en">
+            <head><meta charset="UTF-8"><title>Authorization Error</title>
+            <style>body{font-family:system-ui,sans-serif;max-width:480px;margin:80px auto;padding:0 24px;color:#1a1a1a}
+            .card{background:#fff;border:1px solid #e5e7eb;border-radius:12px;padding:32px}
+            h1{font-size:1.25rem;margin:0 0 12px}p{color:#6b7280;margin:0}</style></head>
+            <body><div class="card">
+            <h1>Authorization Error</h1>
+            <p>$description (${escapeHtml(error)})</p>
+            </div></body></html>
+        """.trimIndent()
+        return ResponseEntity.badRequest().contentType(MediaType.TEXT_HTML).body(html)
+    }
+
+    private fun buildConsentHtml(
+        clientName: String,
+        scopes: List<String>,
+        clientId: String,
+        redirectUri: String,
+        scope: String,
+        state: String?,
+        codeChallenge: String,
+        codeChallengeMethod: String
+    ): String {
+        val scopeLabels = scopes.joinToString(", ") { scopeLabel(it) }
+        val stateField = if (state != null) """<input type="hidden" name="state" value="${escapeHtml(state)}">""" else ""
+        return """
+            <!DOCTYPE html>
+            <html lang="en">
+            <head>
+              <meta charset="UTF-8">
+              <meta name="viewport" content="width=device-width,initial-scale=1">
+              <title>Connect ${escapeHtml(clientName)} — Briefy</title>
+              <style>
+                *, *::before, *::after { box-sizing: border-box; }
+                body { font-family: system-ui, -apple-system, sans-serif; background: #f9fafb;
+                       display: flex; align-items: center; justify-content: center;
+                       min-height: 100vh; margin: 0; padding: 24px; color: #111827; }
+                .card { background: #fff; border: 1px solid #e5e7eb; border-radius: 16px;
+                        padding: 40px 36px; max-width: 420px; width: 100%; box-shadow: 0 1px 3px rgba(0,0,0,.08); }
+                .logo { font-weight: 700; font-size: 1.1rem; color: #111827; margin-bottom: 28px; }
+                h1 { font-size: 1.2rem; font-weight: 600; margin: 0 0 8px; }
+                .subtitle { color: #6b7280; font-size: 0.9rem; margin: 0 0 24px; }
+                .permissions { background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 8px;
+                               padding: 16px; margin-bottom: 28px; }
+                .permissions p { font-size: 0.85rem; color: #6b7280; margin: 0 0 8px; font-weight: 500;
+                                 text-transform: uppercase; letter-spacing: .04em; }
+                .permissions ul { margin: 0; padding: 0 0 0 20px; }
+                .permissions li { font-size: 0.95rem; color: #374151; line-height: 1.6; }
+                .actions { display: flex; gap: 12px; }
+                button { flex: 1; padding: 10px 16px; border-radius: 8px; font-size: 0.95rem;
+                         font-weight: 500; cursor: pointer; border: none; transition: opacity .15s; }
+                button:hover { opacity: .88; }
+                .btn-approve { background: #111827; color: #fff; }
+                .btn-deny { background: #f3f4f6; color: #374151; border: 1px solid #e5e7eb; }
+              </style>
+            </head>
+            <body>
+              <div class="card">
+                <div class="logo">Briefy</div>
+                <h1>${escapeHtml(clientName)} wants access</h1>
+                <p class="subtitle">This will allow ${escapeHtml(clientName)} to access your Briefy account.</p>
+                <div class="permissions">
+                  <p>Permissions requested</p>
+                  <ul><li>$scopeLabels</li></ul>
+                </div>
+                <form method="POST" action="/oauth/authorize">
+                  <input type="hidden" name="client_id" value="${escapeHtml(clientId)}">
+                  <input type="hidden" name="redirect_uri" value="${escapeHtml(redirectUri)}">
+                  <input type="hidden" name="scope" value="${escapeHtml(scope)}">
+                  <input type="hidden" name="code_challenge" value="${escapeHtml(codeChallenge)}">
+                  <input type="hidden" name="code_challenge_method" value="${escapeHtml(codeChallengeMethod)}">
+                  $stateField
+                  <div class="actions">
+                    <button type="submit" name="approved" value="true" class="btn-approve">Authorize</button>
+                    <button type="submit" name="approved" value="false" class="btn-deny">Deny</button>
+                  </div>
+                </form>
+              </div>
+            </body>
+            </html>
+        """.trimIndent()
+    }
+
+    private fun scopeLabel(scope: String): String = when (scope) {
+        "mcp:read" -> "Read your Sources, Briefings, Takeaways, and Topics"
+        else -> escapeHtml(scope)
+    }
+
+    private fun encode(value: String): String = URLEncoder.encode(value, StandardCharsets.UTF_8)
+
+    private fun escapeHtml(value: String): String = value
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\"", "&quot;")
+        .replace("'", "&#x27;")
+}

--- a/apps/api/src/main/kotlin/com/briefy/api/api/oauth/OAuthAuthorizeController.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/api/oauth/OAuthAuthorizeController.kt
@@ -6,6 +6,8 @@ import com.briefy.api.application.oauthserver.OAuthServerService
 import com.briefy.api.infrastructure.security.AuthenticatedUser
 import jakarta.servlet.http.HttpServletRequest
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.context.SecurityContextHolder
@@ -21,7 +23,8 @@ import java.nio.charset.StandardCharsets
 @RestController
 @RequestMapping("/oauth/authorize")
 class OAuthAuthorizeController(
-    private val oauthServerService: OAuthServerService
+    private val oauthServerService: OAuthServerService,
+    @param:Value("\${oauth.server.web-base-url:http://localhost:3000}") private val webBaseUrl: String
 ) {
     private val logger = LoggerFactory.getLogger(OAuthAuthorizeController::class.java)
 
@@ -42,7 +45,7 @@ class OAuthAuthorizeController(
 
         val principal = currentUser()
         if (principal == null) {
-            val loginUrl = "/login?next=${encode(request.requestURI + "?" + request.queryString)}"
+            val loginUrl = buildLoginUrl(request)
             return ResponseEntity.status(302).location(URI.create(loginUrl)).build()
         }
 
@@ -78,36 +81,37 @@ class OAuthAuthorizeController(
         @RequestParam("code_challenge") codeChallenge: String,
         @RequestParam("code_challenge_method") codeChallengeMethod: String,
         @RequestParam("approved", defaultValue = "false") approved: Boolean
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<*> {
         val principal = currentUser()
-            ?: return ResponseEntity.status(302).location(URI.create("/login")).build()
-
-        if (!approved) {
-            val deniedUri = buildRedirectUri(redirectUri, null, "access_denied", "User denied access", state)
-            return ResponseEntity.status(302).location(URI.create(deniedUri)).build()
-        }
+            ?: return ResponseEntity.status(HttpStatus.FOUND).location(URI.create(webLoginUrl())).build<Void>()
 
         val context = try {
             oauthServerService.validateAuthorizationRequest(clientId, redirectUri, scope, codeChallenge, codeChallengeMethod)
         } catch (e: OAuthClientNotFoundException) {
-            val errorUri = buildRedirectUri(redirectUri, null, "invalid_client", "Unknown client", state)
-            return ResponseEntity.status(302).location(URI.create(errorUri)).build()
+            return errorPage("invalid_client", "Unknown client")
+        } catch (e: OAuthInvalidRedirectUriException) {
+            return errorPage("invalid_request", "Redirect URI not allowed")
         } catch (e: Exception) {
             val errorUri = buildRedirectUri(redirectUri, null, "invalid_request", e.message ?: "Invalid request", state)
-            return ResponseEntity.status(302).location(URI.create(errorUri)).build()
+            return ResponseEntity.status(HttpStatus.FOUND).location(URI.create(errorUri)).build<Void>()
+        }
+
+        if (!approved) {
+            val deniedUri = buildRedirectUri(context.redirectUri, null, "access_denied", "User denied access", state)
+            return ResponseEntity.status(HttpStatus.FOUND).location(URI.create(deniedUri)).build<Void>()
         }
 
         val code = oauthServerService.issueAuthorizationCode(
             clientId = clientId,
             userId = principal.id,
-            redirectUri = redirectUri,
+            redirectUri = context.redirectUri,
             scopes = context.scopes,
-            codeChallenge = codeChallenge
+            codeChallenge = context.codeChallenge
         )
 
         logger.info("[oauth] Consent granted clientId={} userId={}", clientId, principal.id)
-        val successUri = buildRedirectUri(redirectUri, code, null, null, state)
-        return ResponseEntity.status(302).location(URI.create(successUri)).build()
+        val successUri = buildRedirectUri(context.redirectUri, code, null, null, state)
+        return ResponseEntity.status(HttpStatus.FOUND).location(URI.create(successUri)).build<Void>()
     }
 
     private fun currentUser(): AuthenticatedUser? {
@@ -127,10 +131,12 @@ class OAuthAuthorizeController(
         if (error != null) params.add("error=${encode(error)}")
         if (errorDescription != null) params.add("error_description=${encode(errorDescription)}")
         if (state != null) params.add("state=${encode(state)}")
-        return if (params.isEmpty()) base else "$base?${params.joinToString("&")}"
+        val separator = if (base.contains("?")) "&" else "?"
+        return if (params.isEmpty()) base else "$base$separator${params.joinToString("&")}"
     }
 
     private fun errorPage(error: String, description: String): ResponseEntity<String> {
+        val safeDescription = escapeHtml(description)
         val html = """
             <!DOCTYPE html>
             <html lang="en">
@@ -140,7 +146,7 @@ class OAuthAuthorizeController(
             h1{font-size:1.25rem;margin:0 0 12px}p{color:#6b7280;margin:0}</style></head>
             <body><div class="card">
             <h1>Authorization Error</h1>
-            <p>$description (${escapeHtml(error)})</p>
+            <p>$safeDescription (${escapeHtml(error)})</p>
             </div></body></html>
         """.trimIndent()
         return ResponseEntity.badRequest().contentType(MediaType.TEXT_HTML).body(html)
@@ -220,6 +226,14 @@ class OAuthAuthorizeController(
         "mcp:read" -> "Read your Sources, Briefings, Takeaways, and Topics"
         else -> escapeHtml(scope)
     }
+
+    private fun buildLoginUrl(request: HttpServletRequest): String {
+        val query = request.queryString?.let { "?$it" } ?: ""
+        val authorizeUrl = "${request.requestURI}$query"
+        return "${webLoginUrl()}?next=${encode(authorizeUrl)}"
+    }
+
+    private fun webLoginUrl(): String = "${webBaseUrl.trimEnd('/')}/login"
 
     private fun encode(value: String): String = URLEncoder.encode(value, StandardCharsets.UTF_8)
 

--- a/apps/api/src/main/kotlin/com/briefy/api/api/oauth/OAuthConnectedAppsController.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/api/oauth/OAuthConnectedAppsController.kt
@@ -1,0 +1,37 @@
+package com.briefy.api.api.oauth
+
+import com.briefy.api.application.oauthserver.ConnectedAppInfo
+import com.briefy.api.application.oauthserver.OAuthServerService
+import com.briefy.api.infrastructure.security.CurrentUserProvider
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v1/connected-apps")
+class OAuthConnectedAppsController(
+    private val oauthServerService: OAuthServerService,
+    private val currentUserProvider: CurrentUserProvider
+) {
+    private val logger = LoggerFactory.getLogger(OAuthConnectedAppsController::class.java)
+
+    @GetMapping
+    fun listConnectedApps(): ResponseEntity<List<ConnectedAppInfo>> {
+        val userId = currentUserProvider.requireUserId()
+        val apps = oauthServerService.listActiveGrants(userId)
+        return ResponseEntity.ok(apps)
+    }
+
+    @DeleteMapping("/{grantId}")
+    fun revokeConnectedApp(@PathVariable grantId: UUID): ResponseEntity<Void> {
+        val userId = currentUserProvider.requireUserId()
+        logger.info("[oauth] Revoking connected app grantId={} userId={}", grantId, userId)
+        oauthServerService.revokeGrant(grantId, userId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/apps/api/src/main/kotlin/com/briefy/api/api/oauth/OAuthMetadataController.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/api/oauth/OAuthMetadataController.kt
@@ -1,0 +1,39 @@
+package com.briefy.api.api.oauth
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class OAuthMetadataController(
+    @Value("\${oauth.server.base-url:http://localhost:8080}") private val baseUrl: String
+) {
+
+    @GetMapping("/.well-known/oauth-authorization-server")
+    fun metadata(): OAuthServerMetadata {
+        return OAuthServerMetadata(
+            issuer = baseUrl,
+            authorizationEndpoint = "$baseUrl/oauth/authorize",
+            tokenEndpoint = "$baseUrl/oauth/token",
+            revocationEndpoint = "$baseUrl/oauth/revoke",
+            responseTypesSupported = listOf("code"),
+            grantTypesSupported = listOf("authorization_code", "refresh_token"),
+            codeChallengeMethodsSupported = listOf("S256"),
+            scopesSupported = listOf("mcp:read"),
+            tokenEndpointAuthMethodsSupported = listOf("none")
+        )
+    }
+}
+
+data class OAuthServerMetadata(
+    @JsonProperty("issuer") val issuer: String,
+    @JsonProperty("authorization_endpoint") val authorizationEndpoint: String,
+    @JsonProperty("token_endpoint") val tokenEndpoint: String,
+    @JsonProperty("revocation_endpoint") val revocationEndpoint: String,
+    @JsonProperty("response_types_supported") val responseTypesSupported: List<String>,
+    @JsonProperty("grant_types_supported") val grantTypesSupported: List<String>,
+    @JsonProperty("code_challenge_methods_supported") val codeChallengeMethodsSupported: List<String>,
+    @JsonProperty("scopes_supported") val scopesSupported: List<String>,
+    @JsonProperty("token_endpoint_auth_methods_supported") val tokenEndpointAuthMethodsSupported: List<String>
+)

--- a/apps/api/src/main/kotlin/com/briefy/api/api/oauth/OAuthTokenController.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/api/oauth/OAuthTokenController.kt
@@ -1,0 +1,71 @@
+package com.briefy.api.api.oauth
+
+import com.briefy.api.application.oauthserver.OAuthServerService
+import com.briefy.api.application.oauthserver.TokenResponse
+import com.fasterxml.jackson.annotation.JsonProperty
+import org.slf4j.LoggerFactory
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class OAuthTokenController(
+    private val oauthServerService: OAuthServerService
+) {
+    private val logger = LoggerFactory.getLogger(OAuthTokenController::class.java)
+
+    @PostMapping("/oauth/token", consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE])
+    fun token(
+        @RequestParam("grant_type") grantType: String,
+        @RequestParam("client_id") clientId: String,
+        @RequestParam("code", required = false) code: String?,
+        @RequestParam("redirect_uri", required = false) redirectUri: String?,
+        @RequestParam("code_verifier", required = false) codeVerifier: String?,
+        @RequestParam("refresh_token", required = false) refreshToken: String?
+    ): ResponseEntity<OAuthTokenApiResponse> {
+        logger.info("[oauth] Token request grant_type={} clientId={}", grantType, clientId)
+
+        return when (grantType) {
+            "authorization_code" -> {
+                requireNotNull(code) { "code is required" }
+                requireNotNull(redirectUri) { "redirect_uri is required" }
+                requireNotNull(codeVerifier) { "code_verifier is required" }
+                val result = oauthServerService.exchangeAuthorizationCode(code, clientId, redirectUri, codeVerifier)
+                ResponseEntity.ok(result.toApiResponse())
+            }
+            "refresh_token" -> {
+                requireNotNull(refreshToken) { "refresh_token is required" }
+                val result = oauthServerService.refreshAccessToken(refreshToken, clientId)
+                ResponseEntity.ok(result.toApiResponse())
+            }
+            else -> throw com.briefy.api.application.oauthserver.OAuthUnsupportedGrantTypeException(grantType)
+        }
+    }
+
+    @PostMapping("/oauth/revoke", consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE])
+    fun revoke(
+        @RequestParam("token") token: String
+    ): ResponseEntity<Void> {
+        logger.info("[oauth] Revoke request received")
+        oauthServerService.revokeByRefreshToken(token)
+        return ResponseEntity.ok().build()
+    }
+
+    private fun TokenResponse.toApiResponse() = OAuthTokenApiResponse(
+        accessToken = accessToken,
+        tokenType = tokenType,
+        expiresIn = expiresIn,
+        refreshToken = refreshToken,
+        scope = scope
+    )
+}
+
+data class OAuthTokenApiResponse(
+    @JsonProperty("access_token") val accessToken: String,
+    @JsonProperty("token_type") val tokenType: String,
+    @JsonProperty("expires_in") val expiresIn: Long,
+    @JsonProperty("refresh_token") val refreshToken: String?,
+    @JsonProperty("scope") val scope: String
+)

--- a/apps/api/src/main/kotlin/com/briefy/api/api/oauth/OAuthTokenController.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/api/oauth/OAuthTokenController.kt
@@ -1,5 +1,6 @@
 package com.briefy.api.api.oauth
 
+import com.briefy.api.application.oauthserver.OAuthInvalidRequestException
 import com.briefy.api.application.oauthserver.OAuthServerService
 import com.briefy.api.application.oauthserver.TokenResponse
 import com.fasterxml.jackson.annotation.JsonProperty
@@ -29,14 +30,14 @@ class OAuthTokenController(
 
         return when (grantType) {
             "authorization_code" -> {
-                requireNotNull(code) { "code is required" }
-                requireNotNull(redirectUri) { "redirect_uri is required" }
-                requireNotNull(codeVerifier) { "code_verifier is required" }
+                if (code == null) throw OAuthInvalidRequestException("code is required")
+                if (redirectUri == null) throw OAuthInvalidRequestException("redirect_uri is required")
+                if (codeVerifier == null) throw OAuthInvalidRequestException("code_verifier is required")
                 val result = oauthServerService.exchangeAuthorizationCode(code, clientId, redirectUri, codeVerifier)
                 ResponseEntity.ok(result.toApiResponse())
             }
             "refresh_token" -> {
-                requireNotNull(refreshToken) { "refresh_token is required" }
+                if (refreshToken == null) throw OAuthInvalidRequestException("refresh_token is required")
                 val result = oauthServerService.refreshAccessToken(refreshToken, clientId)
                 ResponseEntity.ok(result.toApiResponse())
             }

--- a/apps/api/src/main/kotlin/com/briefy/api/application/oauthserver/OAuthServerDto.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/application/oauthserver/OAuthServerDto.kt
@@ -1,0 +1,30 @@
+package com.briefy.api.application.oauthserver
+
+import com.briefy.api.domain.identity.oauthserver.OAuthClient
+import java.util.UUID
+
+data class AuthorizationRequestContext(
+    val client: OAuthClient,
+    val redirectUri: String,
+    val scopes: List<String>,
+    val state: String?,
+    val codeChallenge: String,
+    val codeChallengeMethod: String
+)
+
+data class TokenResponse(
+    val accessToken: String,
+    val tokenType: String = "Bearer",
+    val expiresIn: Long,
+    val refreshToken: String?,
+    val scope: String
+)
+
+data class ConnectedAppInfo(
+    val grantId: UUID,
+    val clientId: String,
+    val clientName: String,
+    val scopes: List<String>,
+    val issuedAt: java.time.Instant,
+    val lastUsedAt: java.time.Instant
+)

--- a/apps/api/src/main/kotlin/com/briefy/api/application/oauthserver/OAuthServerDto.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/application/oauthserver/OAuthServerDto.kt
@@ -7,7 +7,6 @@ data class AuthorizationRequestContext(
     val client: OAuthClient,
     val redirectUri: String,
     val scopes: List<String>,
-    val state: String?,
     val codeChallenge: String,
     val codeChallengeMethod: String
 )

--- a/apps/api/src/main/kotlin/com/briefy/api/application/oauthserver/OAuthServerExceptions.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/application/oauthserver/OAuthServerExceptions.kt
@@ -18,6 +18,9 @@ class OAuthInvalidTokenException(message: String = "Invalid or expired token") :
 class OAuthUnsupportedGrantTypeException(grantType: String) :
     RuntimeException("Unsupported grant_type: $grantType")
 
+class OAuthInvalidRequestException(message: String) :
+    RuntimeException(message)
+
 class OAuthPkceRequiredException :
     RuntimeException("PKCE is required for this client")
 

--- a/apps/api/src/main/kotlin/com/briefy/api/application/oauthserver/OAuthServerExceptions.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/application/oauthserver/OAuthServerExceptions.kt
@@ -1,0 +1,25 @@
+package com.briefy.api.application.oauthserver
+
+class OAuthClientNotFoundException(clientId: String) :
+    RuntimeException("OAuth client not found: $clientId")
+
+class OAuthInvalidRedirectUriException(redirectUri: String) :
+    RuntimeException("Redirect URI not allowed: $redirectUri")
+
+class OAuthInvalidScopeException(scope: String) :
+    RuntimeException("Scope not allowed: $scope")
+
+class OAuthInvalidGrantException(message: String = "Invalid or expired authorization code") :
+    RuntimeException(message)
+
+class OAuthInvalidTokenException(message: String = "Invalid or expired token") :
+    RuntimeException(message)
+
+class OAuthUnsupportedGrantTypeException(grantType: String) :
+    RuntimeException("Unsupported grant_type: $grantType")
+
+class OAuthPkceRequiredException :
+    RuntimeException("PKCE is required for this client")
+
+class OAuthPkceVerificationException :
+    RuntimeException("PKCE code_verifier does not match code_challenge")

--- a/apps/api/src/main/kotlin/com/briefy/api/application/oauthserver/OAuthServerService.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/application/oauthserver/OAuthServerService.kt
@@ -1,0 +1,223 @@
+package com.briefy.api.application.oauthserver
+
+import com.briefy.api.domain.identity.oauthserver.OAuthAccessGrant
+import com.briefy.api.domain.identity.oauthserver.OAuthAccessGrantRepository
+import com.briefy.api.domain.identity.oauthserver.OAuthAuthorizationCode
+import com.briefy.api.domain.identity.oauthserver.OAuthAuthorizationCodeRepository
+import com.briefy.api.domain.identity.oauthserver.OAuthClientRepository
+import com.briefy.api.infrastructure.id.IdGenerator
+import com.briefy.api.infrastructure.security.JwtService
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.time.Instant
+import java.util.Base64
+import java.util.UUID
+
+@Service
+class OAuthServerService(
+    private val clientRepository: OAuthClientRepository,
+    private val authCodeRepository: OAuthAuthorizationCodeRepository,
+    private val accessGrantRepository: OAuthAccessGrantRepository,
+    private val jwtService: JwtService,
+    private val idGenerator: IdGenerator,
+    @Value("\${auth.jwt.access-token-minutes:15}") private val accessTokenMinutes: Long,
+    @Value("\${oauth.server.refresh-token-days:90}") private val refreshTokenDays: Long
+) {
+    private val logger = LoggerFactory.getLogger(OAuthServerService::class.java)
+    private val secureRandom = SecureRandom()
+
+    @Transactional(readOnly = true)
+    fun validateAuthorizationRequest(
+        clientId: String,
+        redirectUri: String,
+        scope: String,
+        codeChallenge: String?,
+        codeChallengeMethod: String?
+    ): AuthorizationRequestContext {
+        val client = clientRepository.findByClientId(clientId)
+            ?: throw OAuthClientNotFoundException(clientId)
+
+        if (!client.allowsRedirectUri(redirectUri)) {
+            throw OAuthInvalidRedirectUriException(redirectUri)
+        }
+
+        val requestedScopes = scope.split(" ").filter { it.isNotBlank() }
+        requestedScopes.forEach { s ->
+            if (!client.allowsScope(s)) throw OAuthInvalidScopeException(s)
+        }
+
+        if (client.requirePkce) {
+            if (codeChallenge.isNullOrBlank()) throw OAuthPkceRequiredException()
+            if (codeChallengeMethod != "S256") throw OAuthPkceRequiredException()
+        }
+
+        return AuthorizationRequestContext(
+            client = client,
+            redirectUri = redirectUri,
+            scopes = requestedScopes,
+            state = null,
+            codeChallenge = codeChallenge ?: "",
+            codeChallengeMethod = codeChallengeMethod ?: "S256"
+        )
+    }
+
+    @Transactional
+    fun issueAuthorizationCode(
+        clientId: String,
+        userId: UUID,
+        redirectUri: String,
+        scopes: List<String>,
+        codeChallenge: String
+    ): String {
+        val plainCode = generateOpaqueToken()
+        val codeHash = hashToken(plainCode)
+        val now = Instant.now()
+
+        val code = OAuthAuthorizationCode(
+            id = idGenerator.newId(),
+            codeHash = codeHash,
+            clientId = clientId,
+            userId = userId,
+            scopes = scopes.joinToString(","),
+            codeChallenge = codeChallenge,
+            redirectUri = redirectUri,
+            expiresAt = now.plusSeconds(60)
+        )
+        authCodeRepository.save(code)
+        logger.info("[oauth] Authorization code issued clientId={} userId={}", clientId, userId)
+        return plainCode
+    }
+
+    @Transactional
+    fun exchangeAuthorizationCode(
+        code: String,
+        clientId: String,
+        redirectUri: String,
+        codeVerifier: String
+    ): TokenResponse {
+        val codeHash = hashToken(code)
+        val authCode = authCodeRepository.findByCodeHash(codeHash)
+            ?: throw OAuthInvalidGrantException()
+
+        val now = Instant.now()
+        if (!authCode.isValid(now)) throw OAuthInvalidGrantException("Authorization code expired or already used")
+        if (authCode.clientId != clientId) throw OAuthInvalidGrantException("client_id mismatch")
+        if (authCode.redirectUri != redirectUri) throw OAuthInvalidGrantException("redirect_uri mismatch")
+        if (!verifyPkce(codeVerifier, authCode.codeChallenge)) throw OAuthPkceVerificationException()
+
+        authCode.markUsed(now)
+        authCodeRepository.save(authCode)
+
+        return issueTokens(authCode.userId, clientId, authCode.scopeList(), now)
+    }
+
+    @Transactional
+    fun refreshAccessToken(refreshToken: String, clientId: String): TokenResponse {
+        val tokenHash = hashToken(refreshToken)
+        val grant = accessGrantRepository.findByRefreshTokenHash(tokenHash)
+            ?: throw OAuthInvalidTokenException()
+
+        if (!grant.isActive()) throw OAuthInvalidTokenException("Token has been revoked")
+        if (grant.clientId != clientId) throw OAuthInvalidTokenException("client_id mismatch")
+
+        val now = Instant.now()
+        grant.recordUse(now)
+        accessGrantRepository.save(grant)
+
+        val accessToken = jwtService.generateMcpAccessToken(grant.userId, grant.scopeList(), clientId)
+        logger.info("[oauth] Access token refreshed clientId={} userId={}", clientId, grant.userId)
+        return TokenResponse(
+            accessToken = accessToken,
+            expiresIn = accessTokenMinutes * 60,
+            refreshToken = null,
+            scope = grant.scopes
+        )
+    }
+
+    @Transactional
+    fun revokeByRefreshToken(refreshToken: String) {
+        val tokenHash = hashToken(refreshToken)
+        val grant = accessGrantRepository.findByRefreshTokenHash(tokenHash) ?: return
+        grant.revoke(Instant.now())
+        accessGrantRepository.save(grant)
+        logger.info("[oauth] Grant revoked clientId={} userId={}", grant.clientId, grant.userId)
+    }
+
+    @Transactional(readOnly = true)
+    fun listActiveGrants(userId: UUID): List<ConnectedAppInfo> {
+        val grants = accessGrantRepository.findByUserIdAndRevokedAtIsNull(userId)
+        val clientIds = grants.map { it.clientId }.distinct()
+        val clients = clientIds.mapNotNull { clientRepository.findByClientId(it) }.associateBy { it.clientId }
+
+        return grants.map { grant ->
+            val client = clients[grant.clientId]
+            ConnectedAppInfo(
+                grantId = grant.id,
+                clientId = grant.clientId,
+                clientName = client?.name ?: grant.clientId,
+                scopes = grant.scopeList(),
+                issuedAt = grant.issuedAt,
+                lastUsedAt = grant.lastUsedAt
+            )
+        }
+    }
+
+    @Transactional
+    fun revokeGrant(grantId: UUID, userId: UUID) {
+        val grant = accessGrantRepository.findById(grantId).orElseThrow {
+            OAuthInvalidTokenException("Grant not found")
+        }
+        if (grant.userId != userId) throw OAuthInvalidTokenException("Grant not found")
+        grant.revoke(Instant.now())
+        accessGrantRepository.save(grant)
+        logger.info("[oauth] Grant revoked by user grantId={} userId={}", grantId, userId)
+    }
+
+    private fun issueTokens(userId: UUID, clientId: String, scopes: List<String>, now: Instant): TokenResponse {
+        val refreshToken = generateOpaqueToken()
+        val tokenHash = hashToken(refreshToken)
+
+        val grant = OAuthAccessGrant(
+            id = idGenerator.newId(),
+            clientId = clientId,
+            userId = userId,
+            scopes = scopes.joinToString(","),
+            refreshTokenHash = tokenHash,
+            issuedAt = now,
+            lastUsedAt = now
+        )
+        accessGrantRepository.save(grant)
+
+        val accessToken = jwtService.generateMcpAccessToken(userId, scopes, clientId)
+        logger.info("[oauth] Tokens issued clientId={} userId={}", clientId, userId)
+        return TokenResponse(
+            accessToken = accessToken,
+            expiresIn = accessTokenMinutes * 60,
+            refreshToken = refreshToken,
+            scope = scopes.joinToString(" ")
+        )
+    }
+
+    private fun verifyPkce(codeVerifier: String, codeChallenge: String): Boolean {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val hash = digest.digest(codeVerifier.toByteArray(Charsets.US_ASCII))
+        val computed = Base64.getUrlEncoder().withoutPadding().encodeToString(hash)
+        return computed == codeChallenge
+    }
+
+    private fun hashToken(token: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val hash = digest.digest(token.toByteArray(Charsets.UTF_8))
+        return Base64.getEncoder().encodeToString(hash)
+    }
+
+    private fun generateOpaqueToken(): String {
+        val bytes = ByteArray(48)
+        secureRandom.nextBytes(bytes)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+    }
+}

--- a/apps/api/src/main/kotlin/com/briefy/api/application/oauthserver/OAuthServerService.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/application/oauthserver/OAuthServerService.kt
@@ -24,8 +24,8 @@ class OAuthServerService(
     private val accessGrantRepository: OAuthAccessGrantRepository,
     private val jwtService: JwtService,
     private val idGenerator: IdGenerator,
-    @Value("\${auth.jwt.access-token-minutes:15}") private val accessTokenMinutes: Long,
-    @Value("\${oauth.server.refresh-token-days:90}") private val refreshTokenDays: Long
+    @param:Value("\${auth.jwt.access-token-minutes:15}") private val accessTokenMinutes: Long,
+    @param:Value("\${oauth.server.refresh-token-days:90}") private val refreshTokenDays: Long
 ) {
     private val logger = LoggerFactory.getLogger(OAuthServerService::class.java)
     private val secureRandom = SecureRandom()
@@ -52,14 +52,15 @@ class OAuthServerService(
 
         if (client.requirePkce) {
             if (codeChallenge.isNullOrBlank()) throw OAuthPkceRequiredException()
-            if (codeChallengeMethod != "S256") throw OAuthPkceRequiredException()
+            if (codeChallengeMethod != "S256") {
+                throw OAuthInvalidRequestException("Unsupported code_challenge_method: only S256 is supported")
+            }
         }
 
         return AuthorizationRequestContext(
             client = client,
             redirectUri = redirectUri,
             scopes = requestedScopes,
-            state = null,
             codeChallenge = codeChallenge ?: "",
             codeChallengeMethod = codeChallengeMethod ?: "S256"
         )
@@ -121,10 +122,10 @@ class OAuthServerService(
         val grant = accessGrantRepository.findByRefreshTokenHash(tokenHash)
             ?: throw OAuthInvalidTokenException()
 
-        if (!grant.isActive()) throw OAuthInvalidTokenException("Token has been revoked")
+        val now = Instant.now()
+        if (!grant.isActive(now)) throw OAuthInvalidTokenException("Token has been revoked or expired")
         if (grant.clientId != clientId) throw OAuthInvalidTokenException("client_id mismatch")
 
-        val now = Instant.now()
         grant.recordUse(now)
         accessGrantRepository.save(grant)
 
@@ -134,7 +135,7 @@ class OAuthServerService(
             accessToken = accessToken,
             expiresIn = accessTokenMinutes * 60,
             refreshToken = null,
-            scope = grant.scopes
+            scope = grant.scopeList().joinToString(" ")
         )
     }
 
@@ -149,7 +150,7 @@ class OAuthServerService(
 
     @Transactional(readOnly = true)
     fun listActiveGrants(userId: UUID): List<ConnectedAppInfo> {
-        val grants = accessGrantRepository.findByUserIdAndRevokedAtIsNull(userId)
+        val grants = accessGrantRepository.findActiveByUserId(userId, Instant.now())
         val clientIds = grants.map { it.clientId }.distinct()
         val clients = clientIds.mapNotNull { clientRepository.findByClientId(it) }.associateBy { it.clientId }
 
@@ -181,6 +182,9 @@ class OAuthServerService(
         val refreshToken = generateOpaqueToken()
         val tokenHash = hashToken(refreshToken)
 
+        accessGrantRepository.findByUserIdAndClientIdAndRevokedAtIsNull(userId, clientId)
+            .forEach { it.revoke(now) }
+
         val grant = OAuthAccessGrant(
             id = idGenerator.newId(),
             clientId = clientId,
@@ -188,7 +192,8 @@ class OAuthServerService(
             scopes = scopes.joinToString(","),
             refreshTokenHash = tokenHash,
             issuedAt = now,
-            lastUsedAt = now
+            lastUsedAt = now,
+            expiresAt = now.plusSeconds(refreshTokenDays * SECONDS_PER_DAY)
         )
         accessGrantRepository.save(grant)
 
@@ -219,5 +224,9 @@ class OAuthServerService(
         val bytes = ByteArray(48)
         secureRandom.nextBytes(bytes)
         return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+    }
+
+    private companion object {
+        const val SECONDS_PER_DAY = 24 * 60 * 60L
     }
 }

--- a/apps/api/src/main/kotlin/com/briefy/api/config/SecurityConfig.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/config/SecurityConfig.kt
@@ -42,6 +42,8 @@ class SecurityConfig(
                     .requestMatchers("/api/health").permitAll()
                     .requestMatchers("/api/public/**").permitAll()
                     .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                    .requestMatchers("/oauth/authorize", "/oauth/token", "/oauth/revoke").permitAll()
+                    .requestMatchers("/.well-known/oauth-authorization-server").permitAll()
                     .anyRequest().authenticated()
             }
             .exceptionHandling {

--- a/apps/api/src/main/kotlin/com/briefy/api/domain/identity/oauthserver/OAuthAccessGrant.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/domain/identity/oauthserver/OAuthAccessGrant.kt
@@ -1,0 +1,48 @@
+package com.briefy.api.domain.identity.oauthserver
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "oauth_access_grants")
+class OAuthAccessGrant(
+    @Id
+    val id: UUID,
+
+    @Column(name = "client_id", nullable = false, length = 100)
+    val clientId: String,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: UUID,
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    val scopes: String,
+
+    @Column(name = "refresh_token_hash", nullable = false, unique = true, length = 255)
+    val refreshTokenHash: String,
+
+    @Column(name = "issued_at", nullable = false)
+    val issuedAt: Instant,
+
+    @Column(name = "last_used_at", nullable = false)
+    var lastUsedAt: Instant,
+
+    @Column(name = "revoked_at")
+    var revokedAt: Instant? = null
+) {
+    fun isActive(): Boolean = revokedAt == null
+
+    fun revoke(now: Instant) {
+        revokedAt = now
+    }
+
+    fun recordUse(now: Instant) {
+        lastUsedAt = now
+    }
+
+    fun scopeList(): List<String> = scopes.split(",").map { it.trim() }.filter { it.isNotBlank() }
+}

--- a/apps/api/src/main/kotlin/com/briefy/api/domain/identity/oauthserver/OAuthAccessGrant.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/domain/identity/oauthserver/OAuthAccessGrant.kt
@@ -31,10 +31,13 @@ class OAuthAccessGrant(
     @Column(name = "last_used_at", nullable = false)
     var lastUsedAt: Instant,
 
+    @Column(name = "expires_at", nullable = false)
+    val expiresAt: Instant,
+
     @Column(name = "revoked_at")
     var revokedAt: Instant? = null
 ) {
-    fun isActive(): Boolean = revokedAt == null
+    fun isActive(now: Instant): Boolean = revokedAt == null && expiresAt.isAfter(now)
 
     fun revoke(now: Instant) {
         revokedAt = now

--- a/apps/api/src/main/kotlin/com/briefy/api/domain/identity/oauthserver/OAuthAccessGrantRepository.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/domain/identity/oauthserver/OAuthAccessGrantRepository.kt
@@ -1,0 +1,12 @@
+package com.briefy.api.domain.identity.oauthserver
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface OAuthAccessGrantRepository : JpaRepository<OAuthAccessGrant, UUID> {
+    fun findByRefreshTokenHash(refreshTokenHash: String): OAuthAccessGrant?
+    fun findByUserIdAndClientIdAndRevokedAtIsNull(userId: UUID, clientId: String): OAuthAccessGrant?
+    fun findByUserIdAndRevokedAtIsNull(userId: UUID): List<OAuthAccessGrant>
+}

--- a/apps/api/src/main/kotlin/com/briefy/api/domain/identity/oauthserver/OAuthAccessGrantRepository.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/domain/identity/oauthserver/OAuthAccessGrantRepository.kt
@@ -1,12 +1,24 @@
 package com.briefy.api.domain.identity.oauthserver
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import java.time.Instant
 import java.util.UUID
 
 @Repository
 interface OAuthAccessGrantRepository : JpaRepository<OAuthAccessGrant, UUID> {
     fun findByRefreshTokenHash(refreshTokenHash: String): OAuthAccessGrant?
-    fun findByUserIdAndClientIdAndRevokedAtIsNull(userId: UUID, clientId: String): OAuthAccessGrant?
-    fun findByUserIdAndRevokedAtIsNull(userId: UUID): List<OAuthAccessGrant>
+    fun findByUserIdAndClientIdAndRevokedAtIsNull(userId: UUID, clientId: String): List<OAuthAccessGrant>
+
+    @Query(
+        """
+        select grant
+        from OAuthAccessGrant grant
+        where grant.userId = :userId
+          and grant.revokedAt is null
+          and grant.expiresAt > :now
+        """
+    )
+    fun findActiveByUserId(userId: UUID, now: Instant): List<OAuthAccessGrant>
 }

--- a/apps/api/src/main/kotlin/com/briefy/api/domain/identity/oauthserver/OAuthAuthorizationCode.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/domain/identity/oauthserver/OAuthAuthorizationCode.kt
@@ -1,0 +1,47 @@
+package com.briefy.api.domain.identity.oauthserver
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "oauth_authorization_codes")
+class OAuthAuthorizationCode(
+    @Id
+    val id: UUID,
+
+    @Column(name = "code_hash", nullable = false, unique = true, length = 255)
+    val codeHash: String,
+
+    @Column(name = "client_id", nullable = false, length = 100)
+    val clientId: String,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: UUID,
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    val scopes: String,
+
+    @Column(name = "code_challenge", nullable = false, length = 255)
+    val codeChallenge: String,
+
+    @Column(name = "redirect_uri", nullable = false, columnDefinition = "TEXT")
+    val redirectUri: String,
+
+    @Column(name = "expires_at", nullable = false)
+    val expiresAt: Instant,
+
+    @Column(name = "used_at")
+    var usedAt: Instant? = null
+) {
+    fun isValid(now: Instant): Boolean = usedAt == null && expiresAt.isAfter(now)
+
+    fun markUsed(now: Instant) {
+        usedAt = now
+    }
+
+    fun scopeList(): List<String> = scopes.split(",").map { it.trim() }.filter { it.isNotBlank() }
+}

--- a/apps/api/src/main/kotlin/com/briefy/api/domain/identity/oauthserver/OAuthAuthorizationCodeRepository.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/domain/identity/oauthserver/OAuthAuthorizationCodeRepository.kt
@@ -1,0 +1,10 @@
+package com.briefy.api.domain.identity.oauthserver
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface OAuthAuthorizationCodeRepository : JpaRepository<OAuthAuthorizationCode, UUID> {
+    fun findByCodeHash(codeHash: String): OAuthAuthorizationCode?
+}

--- a/apps/api/src/main/kotlin/com/briefy/api/domain/identity/oauthserver/OAuthClient.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/domain/identity/oauthserver/OAuthClient.kt
@@ -1,0 +1,41 @@
+package com.briefy.api.domain.identity.oauthserver
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "oauth_clients")
+class OAuthClient(
+    @Id
+    val id: UUID,
+
+    @Column(name = "client_id", nullable = false, unique = true, length = 100)
+    val clientId: String,
+
+    @Column(nullable = false, length = 255)
+    val name: String,
+
+    @Column(name = "allowed_redirect_uris", nullable = false, columnDefinition = "TEXT")
+    val allowedRedirectUris: String,
+
+    @Column(name = "allowed_scopes", nullable = false, columnDefinition = "TEXT")
+    val allowedScopes: String,
+
+    @Column(name = "require_pkce", nullable = false)
+    val requirePkce: Boolean,
+
+    @Column(name = "created_at", nullable = false)
+    val createdAt: Instant
+) {
+    fun redirectUriList(): List<String> = allowedRedirectUris.split(",").map { it.trim() }
+
+    fun scopeList(): List<String> = allowedScopes.split(",").map { it.trim() }
+
+    fun allowsRedirectUri(uri: String): Boolean = redirectUriList().any { it == uri }
+
+    fun allowsScope(scope: String): Boolean = scopeList().any { it == scope }
+}

--- a/apps/api/src/main/kotlin/com/briefy/api/domain/identity/oauthserver/OAuthClientRepository.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/domain/identity/oauthserver/OAuthClientRepository.kt
@@ -1,0 +1,10 @@
+package com.briefy.api.domain.identity.oauthserver
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface OAuthClientRepository : JpaRepository<OAuthClient, UUID> {
+    fun findByClientId(clientId: String): OAuthClient?
+}

--- a/apps/api/src/main/kotlin/com/briefy/api/infrastructure/security/JwtService.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/infrastructure/security/JwtService.kt
@@ -53,8 +53,37 @@ class JwtService(
         return AuthenticatedUser(userId, email, role)
     }
 
+    fun generateMcpAccessToken(userId: UUID, scopes: List<String>, clientId: String): String {
+        val now = Instant.now()
+        val expiresAt = now.plusSeconds(accessTokenMinutes * 60)
+        return Jwts.builder()
+            .subject(userId.toString())
+            .claim(CLAIM_SCOPE, scopes.joinToString(" "))
+            .claim(CLAIM_CLIENT_ID, clientId)
+            .issuedAt(Date.from(now))
+            .expiration(Date.from(expiresAt))
+            .signWith(key)
+            .compact()
+    }
+
+    fun parseMcpAccessToken(token: String): OAuthPrincipal? {
+        return try {
+            val claims = Jwts.parser().verifyWith(key).build()
+                .parseSignedClaims(token)
+                .payload
+            val scopeStr = claims.get(CLAIM_SCOPE, String::class.java) ?: return null
+            val userId = UUID.fromString(claims.subject)
+            val scopes = scopeStr.split(" ").filter { it.isNotBlank() }
+            OAuthPrincipal(userId, scopes)
+        } catch (_: Exception) {
+            null
+        }
+    }
+
     companion object {
         private const val CLAIM_EMAIL = "email"
         private const val CLAIM_ROLE = "role"
+        private const val CLAIM_SCOPE = "scope"
+        private const val CLAIM_CLIENT_ID = "client_id"
     }
 }

--- a/apps/api/src/main/kotlin/com/briefy/api/infrastructure/security/OAuthPrincipal.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/infrastructure/security/OAuthPrincipal.kt
@@ -1,0 +1,10 @@
+package com.briefy.api.infrastructure.security
+
+import java.util.UUID
+
+data class OAuthPrincipal(
+    val userId: UUID,
+    val scopes: List<String>
+) {
+    fun hasScope(scope: String): Boolean = scopes.contains(scope)
+}

--- a/apps/api/src/main/kotlin/com/briefy/api/infrastructure/security/OAuthTokenValidator.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/infrastructure/security/OAuthTokenValidator.kt
@@ -1,0 +1,20 @@
+package com.briefy.api.infrastructure.security
+
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.stereotype.Component
+
+@Component
+class OAuthTokenValidator(private val jwtService: JwtService) {
+
+    fun validate(bearerToken: String): OAuthPrincipal? {
+        val principal = jwtService.parseMcpAccessToken(bearerToken) ?: return null
+        if (!principal.hasScope("mcp:read")) return null
+        return principal
+    }
+
+    fun extractFromRequest(request: HttpServletRequest): OAuthPrincipal? {
+        val authHeader = request.getHeader("Authorization") ?: return null
+        if (!authHeader.startsWith("Bearer ")) return null
+        return validate(authHeader.removePrefix("Bearer ").trim())
+    }
+}

--- a/apps/api/src/main/kotlin/com/briefy/api/infrastructure/security/OAuthTokenValidator.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/infrastructure/security/OAuthTokenValidator.kt
@@ -14,7 +14,7 @@ class OAuthTokenValidator(private val jwtService: JwtService) {
 
     fun extractFromRequest(request: HttpServletRequest): OAuthPrincipal? {
         val authHeader = request.getHeader("Authorization") ?: return null
-        if (!authHeader.startsWith("Bearer ")) return null
-        return validate(authHeader.removePrefix("Bearer ").trim())
+        if (!authHeader.startsWith("Bearer ", ignoreCase = true)) return null
+        return validate(authHeader.substringAfter(" ").trim())
     }
 }

--- a/apps/api/src/main/resources/application.yml
+++ b/apps/api/src/main/resources/application.yml
@@ -67,6 +67,11 @@ auth:
     secure: ${AUTH_COOKIE_SECURE:false}
     same-site: ${AUTH_COOKIE_SAME_SITE:Lax}
 
+oauth:
+  server:
+    base-url: ${OAUTH_SERVER_BASE_URL:http://localhost:8080}
+    refresh-token-days: ${OAUTH_REFRESH_TOKEN_DAYS:90}
+
 security:
   encryption-key: ${ENCRYPTION_KEY:MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=}
 

--- a/apps/api/src/main/resources/application.yml
+++ b/apps/api/src/main/resources/application.yml
@@ -70,6 +70,7 @@ auth:
 oauth:
   server:
     base-url: ${OAUTH_SERVER_BASE_URL:http://localhost:8080}
+    web-base-url: ${BRIEFY_WEB_BASE_URL:http://localhost:3000}
     refresh-token-days: ${OAUTH_REFRESH_TOKEN_DAYS:90}
 
 security:

--- a/apps/api/src/main/resources/db/migration/V20260426120000__oauth_server.sql
+++ b/apps/api/src/main/resources/db/migration/V20260426120000__oauth_server.sql
@@ -1,0 +1,48 @@
+CREATE TABLE oauth_clients (
+    id UUID PRIMARY KEY,
+    client_id VARCHAR(100) NOT NULL UNIQUE,
+    name VARCHAR(255) NOT NULL,
+    allowed_redirect_uris TEXT NOT NULL,
+    allowed_scopes TEXT NOT NULL,
+    require_pkce BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE oauth_authorization_codes (
+    id UUID PRIMARY KEY,
+    code_hash VARCHAR(255) NOT NULL UNIQUE,
+    client_id VARCHAR(100) NOT NULL,
+    user_id UUID NOT NULL REFERENCES users(id),
+    scopes TEXT NOT NULL,
+    code_challenge VARCHAR(255) NOT NULL,
+    redirect_uri TEXT NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    used_at TIMESTAMPTZ
+);
+
+CREATE INDEX oauth_authorization_codes_expires_at_idx ON oauth_authorization_codes (expires_at);
+
+CREATE TABLE oauth_access_grants (
+    id UUID PRIMARY KEY,
+    client_id VARCHAR(100) NOT NULL,
+    user_id UUID NOT NULL REFERENCES users(id),
+    scopes TEXT NOT NULL,
+    refresh_token_hash VARCHAR(255) NOT NULL UNIQUE,
+    issued_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_used_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    revoked_at TIMESTAMPTZ
+);
+
+CREATE INDEX oauth_access_grants_user_id_idx ON oauth_access_grants (user_id);
+CREATE INDEX oauth_access_grants_client_id_user_id_idx ON oauth_access_grants (client_id, user_id);
+
+INSERT INTO oauth_clients (id, client_id, name, allowed_redirect_uris, allowed_scopes, require_pkce, created_at)
+VALUES (
+    'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    'espriu',
+    'Espriu',
+    'https://espriu.app/oauth/callback,http://localhost:3001/oauth/callback',
+    'mcp:read',
+    TRUE,
+    CURRENT_TIMESTAMP
+);

--- a/apps/api/src/main/resources/db/migration/V20260426120000__oauth_server.sql
+++ b/apps/api/src/main/resources/db/migration/V20260426120000__oauth_server.sql
@@ -11,7 +11,7 @@ CREATE TABLE oauth_clients (
 CREATE TABLE oauth_authorization_codes (
     id UUID PRIMARY KEY,
     code_hash VARCHAR(255) NOT NULL UNIQUE,
-    client_id VARCHAR(100) NOT NULL,
+    client_id VARCHAR(100) NOT NULL REFERENCES oauth_clients(client_id),
     user_id UUID NOT NULL REFERENCES users(id),
     scopes TEXT NOT NULL,
     code_challenge VARCHAR(255) NOT NULL,
@@ -24,12 +24,13 @@ CREATE INDEX oauth_authorization_codes_expires_at_idx ON oauth_authorization_cod
 
 CREATE TABLE oauth_access_grants (
     id UUID PRIMARY KEY,
-    client_id VARCHAR(100) NOT NULL,
+    client_id VARCHAR(100) NOT NULL REFERENCES oauth_clients(client_id),
     user_id UUID NOT NULL REFERENCES users(id),
     scopes TEXT NOT NULL,
     refresh_token_hash VARCHAR(255) NOT NULL UNIQUE,
     issued_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     last_used_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMPTZ NOT NULL,
     revoked_at TIMESTAMPTZ
 );
 

--- a/apps/api/src/test/kotlin/com/briefy/api/application/oauthserver/OAuthServerServiceTest.kt
+++ b/apps/api/src/test/kotlin/com/briefy/api/application/oauthserver/OAuthServerServiceTest.kt
@@ -1,0 +1,121 @@
+package com.briefy.api.application.oauthserver
+
+import com.briefy.api.domain.identity.oauthserver.OAuthAccessGrant
+import com.briefy.api.domain.identity.oauthserver.OAuthAccessGrantRepository
+import com.briefy.api.domain.identity.oauthserver.OAuthAuthorizationCode
+import com.briefy.api.domain.identity.oauthserver.OAuthAuthorizationCodeRepository
+import com.briefy.api.domain.identity.oauthserver.OAuthClientRepository
+import com.briefy.api.infrastructure.id.IdGenerator
+import com.briefy.api.infrastructure.security.JwtService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.security.MessageDigest
+import java.time.Instant
+import java.util.Base64
+import java.util.UUID
+
+class OAuthServerServiceTest {
+
+    private val clientRepository = mock<OAuthClientRepository>()
+    private val authCodeRepository = mock<OAuthAuthorizationCodeRepository>()
+    private val accessGrantRepository = mock<OAuthAccessGrantRepository>()
+    private val jwtService = JwtService(
+        secret = "test-secret-should-be-at-least-32-bytes-long",
+        accessTokenMinutes = 15
+    )
+    private val idGenerator = object : IdGenerator {
+        override fun newId(): UUID = UUID.randomUUID()
+    }
+
+    private val service = OAuthServerService(
+        clientRepository = clientRepository,
+        authCodeRepository = authCodeRepository,
+        accessGrantRepository = accessGrantRepository,
+        jwtService = jwtService,
+        idGenerator = idGenerator,
+        accessTokenMinutes = 15,
+        refreshTokenDays = 90
+    )
+
+    @Test
+    fun `exchange authorization code expires refresh grant and revokes prior active grant`() {
+        val userId = UUID.randomUUID()
+        val previousGrant = activeGrant(userId = userId)
+        val authCode = OAuthAuthorizationCode(
+            id = UUID.randomUUID(),
+            codeHash = "hash",
+            clientId = "espriu",
+            userId = userId,
+            scopes = "mcp:read",
+            codeChallenge = pkceChallenge("verifier"),
+            redirectUri = "https://espriu.app/oauth/callback",
+            expiresAt = Instant.now().plusSeconds(60)
+        )
+        whenever(authCodeRepository.findByCodeHash(any())).thenReturn(authCode)
+        whenever(accessGrantRepository.findByUserIdAndClientIdAndRevokedAtIsNull(userId, "espriu"))
+            .thenReturn(listOf(previousGrant))
+        whenever(accessGrantRepository.save(any())).thenAnswer { it.arguments[0] }
+
+        val response = service.exchangeAuthorizationCode(
+            code = "code",
+            clientId = "espriu",
+            redirectUri = "https://espriu.app/oauth/callback",
+            codeVerifier = "verifier"
+        )
+
+        val grantCaptor = argumentCaptor<OAuthAccessGrant>()
+        org.mockito.kotlin.verify(accessGrantRepository).save(grantCaptor.capture())
+        assertNotNull(previousGrant.revokedAt)
+        assertTrue(grantCaptor.firstValue.expiresAt.isAfter(grantCaptor.firstValue.issuedAt))
+        assertEquals("mcp:read", response.scope)
+    }
+
+    @Test
+    fun `refresh token rejects expired grants`() {
+        whenever(accessGrantRepository.findByRefreshTokenHash(any())).thenReturn(
+            activeGrant(expiresAt = Instant.now().minusSeconds(1))
+        )
+
+        assertThrows<OAuthInvalidTokenException> {
+            service.refreshAccessToken("refresh-token", "espriu")
+        }
+    }
+
+    @Test
+    fun `refresh token returns space-delimited scopes`() {
+        val grant = activeGrant(scopes = "mcp:read,profile:read")
+        whenever(accessGrantRepository.findByRefreshTokenHash(any())).thenReturn(grant)
+        whenever(accessGrantRepository.save(any())).thenAnswer { it.arguments[0] }
+
+        val response = service.refreshAccessToken("refresh-token", "espriu")
+
+        assertEquals("mcp:read profile:read", response.scope)
+    }
+
+    private fun activeGrant(
+        userId: UUID = UUID.randomUUID(),
+        scopes: String = "mcp:read",
+        expiresAt: Instant = Instant.now().plusSeconds(60)
+    ) = OAuthAccessGrant(
+        id = UUID.randomUUID(),
+        clientId = "espriu",
+        userId = userId,
+        scopes = scopes,
+        refreshTokenHash = "hash",
+        issuedAt = Instant.now(),
+        lastUsedAt = Instant.now(),
+        expiresAt = expiresAt
+    )
+
+    private fun pkceChallenge(verifier: String): String {
+        val hash = MessageDigest.getInstance("SHA-256").digest(verifier.toByteArray(Charsets.US_ASCII))
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(hash)
+    }
+}

--- a/apps/api/src/test/kotlin/com/briefy/api/infrastructure/security/OAuthTokenValidatorTest.kt
+++ b/apps/api/src/test/kotlin/com/briefy/api/infrastructure/security/OAuthTokenValidatorTest.kt
@@ -1,0 +1,30 @@
+package com.briefy.api.infrastructure.security
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+import java.util.UUID
+
+class OAuthTokenValidatorTest {
+
+    private val jwtService = JwtService(
+        secret = "test-secret-should-be-at-least-32-bytes-long",
+        accessTokenMinutes = 15
+    )
+    private val validator = OAuthTokenValidator(jwtService)
+
+    @Test
+    fun `extracts bearer token case-insensitively`() {
+        val userId = UUID.randomUUID()
+        val token = jwtService.generateMcpAccessToken(userId, listOf("mcp:read"), "espriu")
+        val request = MockHttpServletRequest().apply {
+            addHeader("Authorization", "bearer $token")
+        }
+
+        val principal = validator.extractFromRequest(request)
+
+        assertNotNull(principal)
+        assertEquals(userId, principal!!.userId)
+    }
+}

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -1,28 +1,37 @@
-import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
-import { useState } from 'react'
+import { createFileRoute, Link, redirect, useNavigate } from '@tanstack/react-router'
+import { useEffect, useState } from 'react'
 import type { FormEvent } from 'react'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { login } from '@/lib/api/auth'
 import { ApiClientError } from '@/lib/api/client'
-import { redirectAuthenticatedUser } from '@/lib/auth/requireAuth'
+import { loadCurrentUser } from '@/lib/auth/session'
 import { useAuth } from '@/lib/auth/useAuth'
 
 export const Route = createFileRoute('/login')({
   beforeLoad: async () => {
-    await redirectAuthenticatedUser()
+    const user = await loadCurrentUser()
+    if (!user || getSafeOAuthNextFromLocation()) return
+    throw redirect(redirectToDefault(user.onboardingCompleted))
   },
   component: LoginPage,
 })
 
 function LoginPage() {
   const navigate = useNavigate()
-  const { refreshUser } = useAuth()
+  const { user, isLoading, refreshUser } = useAuth()
+  const [next] = useState(() => getSafeOAuthNextFromLocation())
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (!isLoading && user && next) {
+      window.location.assign(next)
+    }
+  }, [isLoading, user, next])
 
   async function handleSubmit(event: FormEvent) {
     event.preventDefault()
@@ -32,6 +41,10 @@ function LoginPage() {
     try {
       await login({ email: email.trim(), password })
       const user = await refreshUser()
+      if (next) {
+        window.location.assign(next)
+        return
+      }
       await navigate({ to: user?.onboardingCompleted ? '/sources' : '/onboarding' })
     } catch (e) {
       if (e instanceof ApiClientError) {
@@ -130,4 +143,20 @@ function LoginPage() {
       </div>
     </div>
   )
+}
+
+function isSafeOAuthNext(next: string): boolean {
+  return next === '/oauth/authorize' || next.startsWith('/oauth/authorize?')
+}
+
+function getSafeOAuthNextFromLocation(): string | undefined {
+  if (typeof window === 'undefined') return undefined
+  const next = new URLSearchParams(window.location.search).get('next')
+  return next && isSafeOAuthNext(next) ? next : undefined
+}
+
+function redirectToDefault(onboardingCompleted: boolean) {
+  return onboardingCompleted
+    ? { to: '/library' as const, search: { tab: 'sources' as const } }
+    : { to: '/onboarding' as const }
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -73,6 +73,10 @@ export default defineConfig(({ mode }) => {
         target: env.API_PROXY_TARGET || 'http://localhost:8081',
         changeOrigin: true,
       },
+      '/oauth': {
+        target: env.API_PROXY_TARGET || 'http://localhost:8081',
+        changeOrigin: true,
+      },
     },
   },
 }


### PR DESCRIPTION
## Summary

- Implements Briefy as an OAuth 2.0 Authorization Server (RFC 6749 + PKCE) so Espriu (and future clients) can connect via a browser-based one-click flow — no token copy-pasting
- Three new domain entities (`OAuthClient`, `OAuthAuthorizationCode`, `OAuthAccessGrant`) in `domain.identity.oauthserver` (distinct from the existing `oauth/` package which handles Google login)
- `OAuthServerService` with full authorize → code → token → revoke lifecycle
- Minimal HTML consent screen at `GET /POST /oauth/authorize` (redirect target, not React)
- `POST /oauth/token` supports `authorization_code` and `refresh_token` grant types; PKCE S256 enforced
- `POST /oauth/revoke` and `GET /.well-known/oauth-authorization-server` RFC 8414 metadata
- `GET/DELETE /api/v1/connected-apps` for user-facing grant management
- `OAuthTokenValidator` in `infrastructure.security` — validates inbound Bearer JWTs and checks `mcp:read` scope, ready to plug into the MCP server auth filter (separate task)
- `JwtService` extended with `generateMcpAccessToken` / `parseMcpAccessToken`; MCP tokens carry a `scope` claim instead of `role`, distinguishing them from session tokens at parse time
- Flyway migration seeds the Espriu client record

## Implementation notes

- Refresh tokens are hashed with SHA-256 (same as `AuthService`) — bcrypt is non-deterministic and can't be used for DB lookup
- Access tokens are short-lived JWTs (15 min, same TTL as session tokens) signed with the same key
- All OAuth params are re-validated on the consent POST — the hidden form fields are convenience, not trust

## Testing

```
cd apps/api && ./gradlew test
# BUILD SUCCESSFUL — all existing tests pass, no regressions
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an OAuth 2.0 Authorization Server with PKCE to enable a one-click browser flow for Espriu and future MCP clients. Includes consent UI, token/refresh/revoke endpoints, scoped JWTs, connected-app management, and a login redirect from consent for unauthenticated users.

- **New Features**
  - OAuth endpoints: GET/POST `/oauth/authorize`, POST `/oauth/token` (`authorization_code`, `refresh_token`), POST `/oauth/revoke`, GET `/.well-known/oauth-authorization-server`.
  - Minimal HTML consent screen; PKCE S256 enforced. Unauthenticated consent redirects to Web `/login?next=/oauth/authorize…` with safe `next` handling.
  - New entities and repos: `OAuthClient`, `OAuthAuthorizationCode`, `OAuthAccessGrant`.
  - `OAuthServerService`: validate → code → token → refresh → revoke; refresh tokens SHA-256 hashed.
  - JWT: `JwtService` adds MCP tokens with `scope`; `OAuthTokenValidator` checks Bearer tokens and `mcp:read`.
  - Connected apps API: GET/DELETE `/api/v1/connected-apps`.
  - Security: public access for OAuth and metadata endpoints; OAuth errors mapped in `GlobalExceptionHandler`.
  - Web: login route supports `next` back to `/oauth/authorize`; dev proxy forwards `/oauth` to API.

- **Migration**
  - Flyway: creates `oauth_clients`, `oauth_authorization_codes`, `oauth_access_grants`; seeds `espriu` client.
  - Config: set `OAUTH_SERVER_BASE_URL`; set `BRIEFY_WEB_BASE_URL` for login redirect; `OAUTH_REFRESH_TOKEN_DAYS` optional.

<sup>Written for commit 13363f91d078cc2d1ea235056036065a9a042bf6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

