### PR TITLE
Proxy /oauth/* and /.well-known/ from web Nginx to API

### DIFF
--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -41,6 +41,26 @@ server {
         proxy_read_timeout 120s;
     }
 
+    location /oauth/ {
+        set $oauth_backend "http://briefy-api.railway.internal:8080";
+        proxy_pass $oauth_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_buffer_size 16k;
+        proxy_buffers 8 256k;
+        proxy_busy_buffers_size 512k;
+        proxy_read_timeout 120s;
+    }
+
+    location = /.well-known/oauth-authorization-server {
+        set $wellknown_backend "http://briefy-api.railway.internal:8080";
+        proxy_pass $wellknown_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    }
+
     location ~ ^/share/(?<share_token>.+)$ {
         error_page 418 = @share_crawler;
         if ($is_crawler) {


### PR DESCRIPTION
## Summary

The OAuth flow currently breaks for real users because the consent screen and the user's session cookie live on different Railway hosts:

- Web app and session cookie: `briefy-web-production.up.railway.app`
- OAuth endpoints (current `OAUTH_SERVER_BASE_URL`): `briefy-api-production.up.railway.app`

When a logged-in user opens `briefy-api…/oauth/authorize?...`, the browser sends no cookie (different origin) → controller redirects to `/login?next=…` on the API host → that path doesn't exist → user lands on a blank/landing page.

This PR proxies the OAuth endpoints through the web Nginx so the browser stays on a single origin where its session cookie is valid:

- `/oauth/*` → `briefy-api.railway.internal:8080`
- `/.well-known/oauth-authorization-server` → `briefy-api.railway.internal:8080`

After this ships, `OAUTH_SERVER_BASE_URL` will be flipped to `https://briefy-web-production.up.railway.app` (already staged on Railway with `skipDeploys`, takes effect on next API deploy).

## Test plan

- [ ] After deploy, `curl https://briefy-web-production.up.railway.app/.well-known/oauth-authorization-server` returns the JSON document with web-host URLs
- [ ] `https://briefy-web-production.up.railway.app/oauth/authorize?client_id=espriu&...` shows the consent screen for a logged-in user (no redirect to login)
- [ ] Full code → token → refresh → revoke flow works end-to-end against the web host

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proxies OAuth endpoints through the web Nginx so the browser stays on the web origin and sends the existing session cookie. Fixes the OAuth consent flow redirect to a non-existent `/login` on the API host.

- **Bug Fixes**
  - Proxy `/oauth/*` and `/.well-known/oauth-authorization-server` to `http://briefy-api.railway.internal:8080`.
  - Forward `Host` and `X-Forwarded-*` headers; set buffer sizes and read timeouts.

- **Migration**
  - Set `OAUTH_SERVER_BASE_URL` to `https://briefy-web-production.up.railway.app` (staged; takes effect on next API deploy).

<sup>Written for commit 02b3e4feeca32edb7064f4c3f89fe48b7e00be8f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

