### PR TITLE
Exclude /oauth/ and /.well-known/ from PWA service worker

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -52,10 +52,15 @@ export default defineConfig(({ mode }) => {
       },
       workbox: {
         navigateFallback: '/index.html',
-        navigateFallbackDenylist: [/^\/api/],
+        navigateFallbackDenylist: [/^\/api/, /^\/oauth\//, /^\/\.well-known\//],
         runtimeCaching: [
           {
             urlPattern: ({ url }) => url.pathname.startsWith('/api'),
+            handler: 'NetworkOnly',
+          },
+          {
+            urlPattern: ({ url }) =>
+              url.pathname.startsWith('/oauth/') || url.pathname.startsWith('/.well-known/'),
             handler: 'NetworkOnly',
           },
         ],

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -52,7 +52,7 @@ export default defineConfig(({ mode }) => {
       },
       workbox: {
         navigateFallback: '/index.html',
-        navigateFallbackDenylist: [/^\/api/, /^\/oauth\//, /^\/\.well-known\//],
+        navigateFallbackDenylist: [/^\/api/, /^\/oauth/, /^\/\.well-known/],
         runtimeCaching: [
           {
             urlPattern: ({ url }) => url.pathname.startsWith('/api'),
@@ -60,7 +60,7 @@ export default defineConfig(({ mode }) => {
           },
           {
             urlPattern: ({ url }) =>
-              url.pathname.startsWith('/oauth/') || url.pathname.startsWith('/.well-known/'),
+              url.pathname.startsWith('/oauth') || url.pathname.startsWith('/.well-known'),
             handler: 'NetworkOnly',
           },
         ],


### PR DESCRIPTION
## Summary

The web service worker (workbox) was caching `/oauth/authorize` and serving the SPA shell instead of letting Nginx proxy the request to the API. This broke the OAuth consent screen for any logged-in user with an active SW.

Verified end-to-end with browser automation: after unregistering the SW, `briefy-web.../oauth/authorize?...` correctly proxies to the API and shows the consent screen.

This change makes that the default by:
- Adding `/oauth/` and `/.well-known/` to `navigateFallbackDenylist` so the SW doesn't fall back to `/index.html` on those paths
- Adding a `NetworkOnly` runtime caching rule for the same paths, mirroring the existing `/api` handling

## Test plan

- [x] `pnpm build` succeeds
- [ ] After deploy, navigate to `/oauth/authorize?...` from a logged-in browser — consent screen renders without manually unregistering the SW

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent the PWA service worker from intercepting OAuth and well-known routes. This fixes the broken OAuth consent screen by always sending these requests to the network/API.

- **Bug Fixes**
  - Added `/oauth` and `/.well-known` to `workbox.navigateFallbackDenylist` (no trailing slash) to avoid SPA fallback and catch bare paths.
  - Added a `NetworkOnly` runtime caching rule for those paths, aligned with `/api`.

<sup>Written for commit 5ebde713069357502e7d2f5d02ec8c8bb15418be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

