### PR TITLE
Pin Railway builder to DOCKERFILE for api and web

### DIFF
--- a/apps/api/railway.json
+++ b/apps/api/railway.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  }
+}

--- a/apps/api/railway.json
+++ b/apps/api/railway.json
@@ -2,6 +2,7 @@
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
     "builder": "DOCKERFILE",
-    "dockerfilePath": "Dockerfile"
+    "dockerfilePath": "Dockerfile",
+    "watchPatterns": ["/apps/api/**"]
   }
 }

--- a/apps/web/railway.json
+++ b/apps/web/railway.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  }
+}

--- a/apps/web/railway.json
+++ b/apps/web/railway.json
@@ -2,6 +2,7 @@
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
     "builder": "DOCKERFILE",
-    "dockerfilePath": "Dockerfile"
+    "dockerfilePath": "Dockerfile",
+    "watchPatterns": ["/apps/web/**"]
   }
 }


### PR DESCRIPTION
## Summary

Two related Railway deploy issues fixed:

### 1. Builder pinning (DOCKERFILE)

Inspecting the manifest snapshots between successful and slow deploys showed Railway was reporting `\"builder\": \"RAILPACK\"` in pre-build deployment metadata, even though the actual build still ran with the Dockerfile. To prevent any future drift (manual dashboard change or default flip), pin the builder in code.

### 2. Watch patterns

The briefy-api service had `watchPatterns: []` (empty) — so every push to main rebuilt the API even when only `apps/web/**` changed. PR #130 (a web-only SW config change) still triggered a full API rebuild, doubling queue pressure on the Hobby plan single build slot. The web service already had correct patterns; the API didn't.

The recent 10+ min queue time was caused by both services queuing simultaneously and serializing on a single build slot. Skipping the API rebuild on web-only PRs (and vice-versa) halves that contention.

## Changes

- `apps/api/railway.json`: pin `DOCKERFILE` builder, watch `/apps/api/**`
- `apps/web/railway.json`: pin `DOCKERFILE` builder, watch `/apps/web/**`

## Test plan

- [ ] After merge, the next deploy reports `\"builder\": \"DOCKERFILE\"` in metadata (already de-facto true; this just locks it in)
- [ ] A web-only follow-up PR triggers only `briefy-web`, not `briefy-api`
- [ ] An api-only follow-up PR triggers only `briefy-api`, not `briefy-web`

🤖 Generated with [Claude Code](https://claude.com/claude-code)