### PR TITLE
feat(mcp): wire MCP server end-to-end for browser-based OAuth clients

### DIFF
--- a/apps/api/src/main/kotlin/com/briefy/api/api/oauth/OAuthAuthorizeController.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/api/oauth/OAuthAuthorizeController.kt
@@ -21,7 +21,7 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 @RestController
-@RequestMapping("/oauth/authorize")
+@RequestMapping(value = ["/oauth/authorize", "/authorize"])
 class OAuthAuthorizeController(
     private val oauthServerService: OAuthServerService,
     @param:Value("\${oauth.server.web-base-url:http://localhost:3000}") private val webBaseUrl: String

--- a/apps/api/src/main/kotlin/com/briefy/api/api/oauth/OAuthMetadataController.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/api/oauth/OAuthMetadataController.kt
@@ -7,7 +7,8 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class OAuthMetadataController(
-    @Value("\${oauth.server.base-url:http://localhost:8080}") private val baseUrl: String
+    @Value("\${oauth.server.base-url:http://localhost:8080}") private val baseUrl: String,
+    @Value("\${mcp.resource-base-url:#{null}}") private val mcpResourceBaseUrl: String?,
 ) {
 
     @GetMapping("/.well-known/oauth-authorization-server")
@@ -24,6 +25,16 @@ class OAuthMetadataController(
             tokenEndpointAuthMethodsSupported = listOf("none")
         )
     }
+
+    @GetMapping(value = ["/.well-known/oauth-protected-resource", "/.well-known/oauth-protected-resource/**"])
+    fun protectedResource(): OAuthProtectedResourceMetadata {
+        return OAuthProtectedResourceMetadata(
+            resource = (mcpResourceBaseUrl ?: baseUrl),
+            authorizationServers = listOf(baseUrl),
+            scopesSupported = listOf("mcp:read"),
+            bearerMethodsSupported = listOf("header"),
+        )
+    }
 }
 
 data class OAuthServerMetadata(
@@ -36,4 +47,11 @@ data class OAuthServerMetadata(
     @JsonProperty("code_challenge_methods_supported") val codeChallengeMethodsSupported: List<String>,
     @JsonProperty("scopes_supported") val scopesSupported: List<String>,
     @JsonProperty("token_endpoint_auth_methods_supported") val tokenEndpointAuthMethodsSupported: List<String>
+)
+
+data class OAuthProtectedResourceMetadata(
+    @JsonProperty("resource") val resource: String,
+    @JsonProperty("authorization_servers") val authorizationServers: List<String>,
+    @JsonProperty("scopes_supported") val scopesSupported: List<String>,
+    @JsonProperty("bearer_methods_supported") val bearerMethodsSupported: List<String>,
 )

--- a/apps/api/src/main/kotlin/com/briefy/api/api/oauth/OAuthTokenController.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/api/oauth/OAuthTokenController.kt
@@ -17,7 +17,7 @@ class OAuthTokenController(
 ) {
     private val logger = LoggerFactory.getLogger(OAuthTokenController::class.java)
 
-    @PostMapping("/oauth/token", consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE])
+    @PostMapping(value = ["/oauth/token", "/token"], consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE])
     fun token(
         @RequestParam("grant_type") grantType: String,
         @RequestParam("client_id") clientId: String,
@@ -45,7 +45,7 @@ class OAuthTokenController(
         }
     }
 
-    @PostMapping("/oauth/revoke", consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE])
+    @PostMapping(value = ["/oauth/revoke", "/revoke"], consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE])
     fun revoke(
         @RequestParam("token") token: String
     ): ResponseEntity<Void> {

--- a/apps/api/src/main/kotlin/com/briefy/api/config/SecurityConfig.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/config/SecurityConfig.kt
@@ -5,6 +5,7 @@ import com.briefy.api.infrastructure.logging.RequestMdcFilter
 import com.briefy.api.infrastructure.security.JwtAuthenticationFilter
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.annotation.Order
@@ -18,6 +19,9 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 import java.time.Instant
 
 @Configuration
@@ -25,17 +29,20 @@ import java.time.Instant
 class SecurityConfig(
     private val jwtAuthenticationFilter: JwtAuthenticationFilter,
     private val requestMdcFilter: RequestMdcFilter,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    @Value("\${mcp.cors.allowed-origins:http://localhost:6274,http://localhost:3000}") private val mcpCorsOriginsCsv: String,
 ) {
 
     @Bean
     @Order(2)
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
+            .cors { it.configurationSource(oauthCorsSource()) }
             .csrf { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests {
                 it.requestMatchers("/error").permitAll()
+                    .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/auth/signup").permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/auth/login").permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/auth/refresh").permitAll()
@@ -45,7 +52,10 @@ class SecurityConfig(
                     .requestMatchers("/api/public/**").permitAll()
                     .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                     .requestMatchers("/oauth/authorize", "/oauth/token", "/oauth/revoke").permitAll()
+                    .requestMatchers("/authorize", "/token", "/revoke").permitAll()
                     .requestMatchers("/.well-known/oauth-authorization-server").permitAll()
+                    .requestMatchers("/.well-known/oauth-protected-resource", "/.well-known/oauth-protected-resource/**").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/oauth/register", "/register").permitAll()
                     .anyRequest().authenticated()
             }
             .exceptionHandling {
@@ -64,6 +74,21 @@ class SecurityConfig(
 
     @Bean
     fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
+
+    private fun oauthCorsSource(): CorsConfigurationSource {
+        val origins = mcpCorsOriginsCsv.split(",").map { it.trim() }.filter { it.isNotBlank() }
+        val cfg = CorsConfiguration().apply {
+            allowedOrigins = origins
+            allowedMethods = listOf("GET", "POST", "OPTIONS")
+            allowedHeaders = listOf("Authorization", "Content-Type", "Accept")
+            allowCredentials = false
+            maxAge = 3600L
+        }
+        val source = UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/.well-known/**", cfg)
+        source.registerCorsConfiguration("/oauth/**", cfg)
+        return source
+    }
 
     private fun writeError(response: HttpServletResponse, status: HttpStatus, message: String) {
         response.status = status.value()

--- a/apps/api/src/main/kotlin/com/briefy/api/infrastructure/mcp/McpAuthFilter.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/infrastructure/mcp/McpAuthFilter.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
@@ -19,6 +20,7 @@ import java.time.Instant
 class McpAuthFilter(
     private val tokenValidator: OAuthTokenValidator,
     private val objectMapper: ObjectMapper,
+    @Value("\${oauth.server.base-url:http://localhost:8080}") private val authServerBaseUrl: String,
 ) : OncePerRequestFilter() {
 
     override fun doFilterInternal(
@@ -41,7 +43,11 @@ class McpAuthFilter(
 
     private fun writeUnauthorized(response: HttpServletResponse) {
         response.status = HttpStatus.UNAUTHORIZED.value()
-        response.setHeader("WWW-Authenticate", "Bearer realm=\"briefy-mcp\", error=\"invalid_token\"")
+        val resourceMetadataUrl = "$authServerBaseUrl/.well-known/oauth-protected-resource"
+        response.setHeader(
+            "WWW-Authenticate",
+            "Bearer realm=\"briefy-mcp\", error=\"invalid_token\", resource_metadata=\"$resourceMetadataUrl\""
+        )
         response.contentType = MediaType.APPLICATION_JSON_VALUE
         val payload = ErrorResponse(
             status = HttpStatus.UNAUTHORIZED.value(),

--- a/apps/api/src/main/kotlin/com/briefy/api/infrastructure/mcp/McpSecurityConfig.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/infrastructure/mcp/McpSecurityConfig.kt
@@ -1,25 +1,37 @@
 package com.briefy.api.infrastructure.mcp
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.annotation.Order
+import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @Configuration
-class McpSecurityConfig(private val mcpAuthFilter: McpAuthFilter) {
+class McpSecurityConfig(
+    private val mcpAuthFilter: McpAuthFilter,
+    @Value("\${mcp.cors.allowed-origins:http://localhost:6274}") private val allowedOriginsCsv: String,
+) {
 
     @Bean
     @Order(1)
     fun mcpSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
             .securityMatcher("/mcp/**")
+            .cors { it.configurationSource(mcpCorsSource()) }
             .csrf { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
-            .authorizeHttpRequests { it.anyRequest().authenticated() }
+            .authorizeHttpRequests {
+                it.requestMatchers(HttpMethod.OPTIONS, "/mcp/**").permitAll()
+                    .anyRequest().authenticated()
+            }
             .addFilterBefore(mcpAuthFilter, UsernamePasswordAuthenticationFilter::class.java)
             .exceptionHandling {
                 it.authenticationEntryPoint { _, response, _ ->
@@ -33,5 +45,20 @@ class McpSecurityConfig(private val mcpAuthFilter: McpAuthFilter) {
     @Bean
     fun mcpAuthFilterRegistration(filter: McpAuthFilter): FilterRegistrationBean<McpAuthFilter> {
         return FilterRegistrationBean(filter).apply { isEnabled = false }
+    }
+
+    private fun mcpCorsSource(): CorsConfigurationSource {
+        val origins = allowedOriginsCsv.split(",").map { it.trim() }.filter { it.isNotBlank() }
+        val cfg = CorsConfiguration().apply {
+            allowedOrigins = origins
+            allowedMethods = listOf("GET", "POST", "OPTIONS")
+            allowedHeaders = listOf("Authorization", "Content-Type", "Accept", "Mcp-Session-Id", "Last-Event-ID")
+            exposedHeaders = listOf("Mcp-Session-Id", "WWW-Authenticate")
+            allowCredentials = false
+            maxAge = 3600L
+        }
+        return UrlBasedCorsConfigurationSource().apply {
+            registerCorsConfiguration("/mcp/**", cfg)
+        }
     }
 }

--- a/apps/api/src/test/kotlin/com/briefy/api/infrastructure/mcp/McpAuthFilterTest.kt
+++ b/apps/api/src/test/kotlin/com/briefy/api/infrastructure/mcp/McpAuthFilterTest.kt
@@ -26,7 +26,7 @@ class McpAuthFilterTest {
 
     private val tokenValidator: OAuthTokenValidator = mock()
     private val objectMapper = ObjectMapper().findAndRegisterModules()
-    private val filter = McpAuthFilter(tokenValidator, objectMapper)
+    private val filter = McpAuthFilter(tokenValidator, objectMapper, "http://localhost:8081")
 
     @AfterEach
     fun tearDown() {

--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -61,6 +61,28 @@ server {
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     }
 
+    location ^~ /.well-known/oauth-protected-resource {
+        set $wellknown_pr_backend "http://briefy-api.railway.internal:8080";
+        proxy_pass $wellknown_pr_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    }
+
+    location /mcp/ {
+        set $mcp_backend "http://briefy-api.railway.internal:8080";
+        proxy_pass $mcp_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_set_header Connection "";
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 86400s;
+        chunked_transfer_encoding on;
+    }
+
     location ~ ^/share/(?<share_token>.+)$ {
         error_page 418 = @share_crawler;
         if ($is_crawler) {


### PR DESCRIPTION
## Summary
Follow-up to #132. Fixes the actual end-to-end flow for browser-based MCP clients (Inspector, Mastra, Claude Code) that walk the OAuth Authorization Code + PKCE + RFC 9728 dance.

After #132 the MCP server worked when a token was pre-minted, but Inspector's auto-OAuth flow failed at multiple points. This PR fixes:

- **`WWW-Authenticate` header** now carries `resource_metadata=` per RFC 9728 §5.1, so clients can discover the auth server from a single 401.
- **`/.well-known/oauth-protected-resource[/**]` endpoint** added (RFC 9728 Protected Resource Metadata). Path-suffixed variant is supported because some MCP clients probe per-resource-path docs.
- **CORS**:
  - `/mcp/**` chain: dedicated CORS source allowing browser MCP origins. Default allowlist is `http://localhost:6274` (Inspector) for dev.
  - `/oauth/**` + `/.well-known/**` on the main chain: matching CORS so token-exchange XHR and discovery fetches succeed.
  - OPTIONS preflight permitted globally on the matched paths.
- **`/authorize`, `/token`, `/revoke` aliases**: some MCP clients ignore the explicit endpoints from the discovery doc and probe `\${issuer}/authorize` directly. Aliases prevent a fallback 404.
- **nginx**: proxies `/mcp/` to the API with SSE-friendly settings (HTTP/1.1, `proxy_buffering off`, long `proxy_read_timeout`, chunked encoding). Proxies `/.well-known/oauth-protected-resource[/**]` to the API. Without this, the web host serves the SPA on those paths.

## New env vars
| Var | Default | Purpose |
|---|---|---|
| `MCP_CORS_ALLOWED_ORIGINS` | `http://localhost:6274` | CSV of browser origins allowed cross-origin to MCP + OAuth + discovery endpoints |
| `MCP_RESOURCE_BASE_URL` | falls back to `oauth.server.base-url` | What the protected-resource doc advertises as `resource`. Set to the public host clients use. |

## Verified manually
- Local dev: Inspector at `http://localhost:6274` connects via OAuth wizard, lists 7 tools, `tools/call search_sources` returns real source IDs from the user's library.
- All existing security/auth tests still pass.

## Deploy steps (for reviewer)
1. Merge → triggers Railway deploys for both `briefy-api` and `briefy-web`.
2. Set Railway vars on `briefy-api`:
   - `MCP_RESOURCE_BASE_URL=https://briefy-web-production.up.railway.app`
   - `MCP_CORS_ALLOWED_ORIGINS=https://briefy-web-production.up.railway.app,http://localhost:6274`
3. Append `http://localhost:6274/oauth/callback` to the prod `oauth_clients.allowed_redirect_uris` for `espriu` (so reviewers can test against prod from local Inspector).
4. Smoke test: Inspector → `https://briefy-web-production.up.railway.app/mcp/sse` → connect → tools/list returns 7 tools.

## Test plan
- [x] `./gradlew :apps:api:test` green
- [x] `curl http://localhost:8081/mcp/sse` → 401 + `WWW-Authenticate: ... resource_metadata=...`
- [x] `curl http://localhost:8081/.well-known/oauth-protected-resource` → 200 JSON
- [x] CORS preflight on `/mcp/sse` from `Origin: http://localhost:6274` returns ACAO header
- [x] Inspector OAuth wizard completes end-to-end against local
- [ ] Same against prod (post-deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the MCP server end-to-end for browser OAuth clients (Authorization Code + PKCE), fixing Inspector/Mastra/Claude Code auto-OAuth. Adds RFC 9728 discovery, CORS, endpoint aliases, and nginx proxies so browsers can authenticate and stream SSE reliably.

- **New Features**
  - `WWW-Authenticate` now includes `resource_metadata=` per RFC 9728 so clients can discover the auth server from a 401.
  - New `/.well-known/oauth-protected-resource[/**]` endpoint advertises `resource`, `authorization_servers`, scopes, and bearer methods; supports path-suffix probing.
  - CORS enabled for `/mcp/**`, `/oauth/**`, and `/.well-known/**`; allows preflights and exposes needed headers for SSE. Defaults allow `http://localhost:6274`.
  - Aliases added: `/authorize`, `/token`, `/revoke` mirror the `/oauth/*` endpoints for clients that probe root paths.
  - `nginx` proxies `/mcp/` with SSE-friendly settings and forwards `/.well-known/oauth-protected-resource[/**]` to the API to avoid SPA fallthrough.

- **Migration**
  - Set `MCP_RESOURCE_BASE_URL` to the public host (e.g., `https://briefy-web-production.up.railway.app`) and `MCP_CORS_ALLOWED_ORIGINS` to include that host and `http://localhost:6274`.
  - Add `http://localhost:6274/oauth/callback` to the `espriu` client’s allowed redirect URIs for Inspector testing.
  - Post-deploy smoke test: Inspector → connect to `/mcp/sse` on prod → verify tools list and tool calls work.

<sup>Written for commit 05cce6fb6beae5cb510edbd68e4d3d9f684fecd2. Summary will update on new commits. <a href="https://cubic.dev/pr/briefy-ai/briefy/pull/133">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

