### PR TITLE
fix(mcp): prevent edge buffering of SSE responses

### DIFF
--- a/apps/api/src/main/kotlin/com/briefy/api/infrastructure/mcp/McpAuthFilter.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/infrastructure/mcp/McpAuthFilter.kt
@@ -38,6 +38,15 @@ class McpAuthFilter(
         val authentication = UsernamePasswordAuthenticationToken(principal, null, authorities)
         SecurityContextHolder.getContext().authentication = authentication
 
+        // Disable nginx/Fastly buffering on the SSE stream so MCP tool-call
+        // responses flush to the client immediately. Without this, some
+        // edge proxies hold the response until the stream closes, hanging
+        // the client on every tool invocation.
+        if (request.requestURI.startsWith("/mcp/sse")) {
+            response.setHeader("X-Accel-Buffering", "no")
+            response.setHeader("Cache-Control", "no-cache, no-store, no-transform")
+        }
+
         filterChain.doFilter(request, response)
     }
 

--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -78,9 +78,14 @@ server {
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
         proxy_set_header Connection "";
         proxy_buffering off;
+        proxy_request_buffering off;
         proxy_cache off;
         proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
         chunked_transfer_encoding on;
+        # Make sure edge caches don't hold the SSE stream.
+        add_header X-Accel-Buffering no always;
+        add_header Cache-Control "no-cache, no-store, no-transform" always;
     }
 
     location ~ ^/share/(?<share_token>.+)$ {


### PR DESCRIPTION
## Summary
Production tool-call responses on `/mcp/sse` were hanging because Railway's edge layer (Fastly) buffered the SSE stream until close. Initialize and tools/list — small, fast framework responses — flushed; real tool invocations (search_sources, get_topics, etc.) hung.

## Fix
- **McpAuthFilter** sets `X-Accel-Buffering: no` and `Cache-Control: no-cache, no-store, no-transform` on `/mcp/sse` responses so edge proxies and CDNs don't buffer.
- **nginx /mcp/ location** adds the same headers via `add_header always` to enforce them at the proxy boundary, plus `proxy_request_buffering off` and `proxy_send_timeout 86400s` for long-lived streams.

## Why both layers
The API setting the header alone isn't enough if nginx strips it before the edge sees it. nginx setting it alone isn't enough if Spring's response composition overrides it. Belt-and-suspenders.

## Test plan
- [x] Local: `./gradlew :apps:api:test` green
- [x] Local: SSE response carries `X-Accel-Buffering: no`
- [ ] Prod: Inspector tools/call returns within seconds (post-deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent edge buffering of `/mcp/sse` so MCP tool-call responses stream immediately, and add OAuth discovery/CORS updates to support browser MCP clients end-to-end.

- **Bug Fixes**
  - Set `X-Accel-Buffering: no` and `Cache-Control: no-cache, no-store, no-transform` on `/mcp/sse` in `McpAuthFilter`.
  - Update nginx `/mcp/` proxy: HTTP/1.1, `proxy_buffering off`, `proxy_request_buffering off`, `proxy_send_timeout 86400s`, long timeouts, and `add_header ... always` to prevent CDN buffering.

- **New Features**
  - Add `/.well-known/oauth-protected-resource[/**]` (RFC 9728) and include `resource_metadata` in `WWW-Authenticate` 401s; `MCP_RESOURCE_BASE_URL` overrides the resource URL.
  - Enable CORS for `/mcp/**`, `/oauth/**`, and `/.well-known/**`; allow `OPTIONS` preflight. Allowed origins via `MCP_CORS_ALLOWED_ORIGINS` (CSV).
  - Add aliases `/authorize`, `/token`, `/revoke` alongside `/oauth/*` and permit them in security config.
  - Route `/.well-known/oauth-protected-resource` to the API in nginx so it doesn’t fall through to the SPA.

<sup>Written for commit 2d5fe9fbe96a175035a588075d9f761de71526e1. Summary will update on new commits. <a href="https://cubic.dev/pr/briefy-ai/briefy/pull/134?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

