### PR TITLE
fix(mcp): proxy bare /authorize /token /revoke through web nginx

### DIFF
--- a/apps/api/src/main/kotlin/com/briefy/api/infrastructure/mcp/McpAuthFilter.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/infrastructure/mcp/McpAuthFilter.kt
@@ -38,6 +38,15 @@ class McpAuthFilter(
         val authentication = UsernamePasswordAuthenticationToken(principal, null, authorities)
         SecurityContextHolder.getContext().authentication = authentication
 
+        // Disable nginx/Fastly buffering on the SSE stream so MCP tool-call
+        // responses flush to the client immediately. Without this, some
+        // edge proxies hold the response until the stream closes, hanging
+        // the client on every tool invocation.
+        if (request.requestURI.startsWith("/mcp/sse")) {
+            response.setHeader("X-Accel-Buffering", "no")
+            response.setHeader("Cache-Control", "no-cache, no-store, no-transform")
+        }
+
         filterChain.doFilter(request, response)
     }
 

--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -78,9 +78,14 @@ server {
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
         proxy_set_header Connection "";
         proxy_buffering off;
+        proxy_request_buffering off;
         proxy_cache off;
         proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
         chunked_transfer_encoding on;
+        # Make sure edge caches don't hold the SSE stream.
+        add_header X-Accel-Buffering no always;
+        add_header Cache-Control "no-cache, no-store, no-transform" always;
     }
 
     location ~ ^/share/(?<share_token>.+)$ {

--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -54,6 +54,30 @@ server {
         proxy_read_timeout 120s;
     }
 
+    # MCP clients (Inspector v0.21 etc.) probe these bare paths as a fallback
+    # when discovery doesn't pin them down. Forward to the API where the
+    # /authorize, /token, /revoke aliases live.
+    location = /authorize {
+        set $authorize_backend "http://briefy-api.railway.internal:8080";
+        proxy_pass $authorize_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    }
+
+    location = /token {
+        set $token_backend "http://briefy-api.railway.internal:8080";
+        proxy_pass $token_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    }
+
+    location = /revoke {
+        set $revoke_backend "http://briefy-api.railway.internal:8080";
+        proxy_pass $revoke_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    }
+
     location = /.well-known/oauth-authorization-server {
         set $wellknown_backend "http://briefy-api.railway.internal:8080";
         proxy_pass $wellknown_backend;


### PR DESCRIPTION
MCP Inspector v0.21 probes `${origin}/authorize` (and /token, /revoke) as fallback paths when discovery doesn't pin endpoints down. Without nginx routes they hit the SPA and the OAuth wizard breaks.

Espriu (Mastra MCP client) uses the explicit /oauth/* paths from the discovery doc and isn't affected, but adding the proxies makes Inspector work end-to-end and is good defense in depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proxied bare `/authorize`, `/token`, and `/revoke` through web nginx to the API to fix MCP Inspector OAuth fallback paths. Also disabled edge buffering on `/mcp/sse` so tool responses stream immediately.

- **Bug Fixes**
  - Web nginx: add explicit locations for `/authorize`, `/token`, `/revoke` that proxy to the API, avoiding SPA fallback and fixing the Inspector OAuth flow.
  - SSE streaming: set `X-Accel-Buffering: no` and strict `Cache-Control` on `/mcp/sse` responses in both the API and nginx; disable request buffering and extend timeouts to prevent edge/CDN buffering and hangs.

<sup>Written for commit 0ea98dc5c631a7361a9c43b4b448b87c822aece6. Summary will update on new commits. <a href="https://cubic.dev/pr/briefy-ai/briefy/pull/135?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

