### PR TITLE
Fix SW + login allowlist for bare /authorize, /token, /revoke

### DIFF
--- a/apps/api/src/main/kotlin/com/briefy/api/infrastructure/mcp/McpAuthFilter.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/infrastructure/mcp/McpAuthFilter.kt
@@ -38,6 +38,15 @@ class McpAuthFilter(
         val authentication = UsernamePasswordAuthenticationToken(principal, null, authorities)
         SecurityContextHolder.getContext().authentication = authentication
 
+        // Disable nginx/Fastly buffering on the SSE stream so MCP tool-call
+        // responses flush to the client immediately. Without this, some
+        // edge proxies hold the response until the stream closes, hanging
+        // the client on every tool invocation.
+        if (request.requestURI.startsWith("/mcp/sse")) {
+            response.setHeader("X-Accel-Buffering", "no")
+            response.setHeader("Cache-Control", "no-cache, no-store, no-transform")
+        }
+
         filterChain.doFilter(request, response)
     }
 

--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -78,9 +78,14 @@ server {
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
         proxy_set_header Connection "";
         proxy_buffering off;
+        proxy_request_buffering off;
         proxy_cache off;
         proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
         chunked_transfer_encoding on;
+        # Make sure edge caches don't hold the SSE stream.
+        add_header X-Accel-Buffering no always;
+        add_header Cache-Control "no-cache, no-store, no-transform" always;
     }
 
     location ~ ^/share/(?<share_token>.+)$ {

--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -54,6 +54,30 @@ server {
         proxy_read_timeout 120s;
     }
 
+    # MCP clients (Inspector v0.21 etc.) probe these bare paths as a fallback
+    # when discovery doesn't pin them down. Forward to the API where the
+    # /authorize, /token, /revoke aliases live.
+    location = /authorize {
+        set $authorize_backend "http://briefy-api.railway.internal:8080";
+        proxy_pass $authorize_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    }
+
+    location = /token {
+        set $token_backend "http://briefy-api.railway.internal:8080";
+        proxy_pass $token_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    }
+
+    location = /revoke {
+        set $revoke_backend "http://briefy-api.railway.internal:8080";
+        proxy_pass $revoke_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    }
+
     location = /.well-known/oauth-authorization-server {
         set $wellknown_backend "http://briefy-api.railway.internal:8080";
         proxy_pass $wellknown_backend;

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -146,7 +146,12 @@ function LoginPage() {
 }
 
 function isSafeOAuthNext(next: string): boolean {
-  return next === '/oauth/authorize' || next.startsWith('/oauth/authorize?')
+  return (
+    next === '/oauth/authorize' ||
+    next.startsWith('/oauth/authorize?') ||
+    next === '/authorize' ||
+    next.startsWith('/authorize?')
+  )
 }
 
 function getSafeOAuthNextFromLocation(): string | undefined {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -52,7 +52,16 @@ export default defineConfig(({ mode }) => {
       },
       workbox: {
         navigateFallback: '/index.html',
-        navigateFallbackDenylist: [/^\/api/, /^\/oauth/, /^\/\.well-known/],
+        navigateFallbackDenylist: [
+          /^\/api/,
+          /^\/oauth/,
+          /^\/\.well-known/,
+          /^\/authorize/,
+          /^\/token/,
+          /^\/revoke/,
+          /^\/register/,
+          /^\/mcp/,
+        ],
         runtimeCaching: [
           {
             urlPattern: ({ url }) => url.pathname.startsWith('/api'),
@@ -60,7 +69,13 @@ export default defineConfig(({ mode }) => {
           },
           {
             urlPattern: ({ url }) =>
-              url.pathname.startsWith('/oauth') || url.pathname.startsWith('/.well-known'),
+              url.pathname.startsWith('/oauth') ||
+              url.pathname.startsWith('/.well-known') ||
+              url.pathname === '/authorize' ||
+              url.pathname === '/token' ||
+              url.pathname === '/revoke' ||
+              url.pathname === '/register' ||
+              url.pathname.startsWith('/mcp'),
             handler: 'NetworkOnly',
           },
         ],


### PR DESCRIPTION
## Summary
- MCP Inspector v0.21 hits bare `/authorize`, `/token`, `/revoke` rather than `/oauth/*` prefixed aliases. We already proxy these through nginx and the API, but two SPA-layer issues kept breaking the flow:
  1. The PWA service worker fell back to cached `index.html` for `/authorize`, so React Router rendered **Not Found** instead of nginx hitting the API.
  2. `login.tsx` only treated `/oauth/authorize` as a safe `next` target, so post-login users were never bounced back to the consent screen — they landed on the library/onboarding instead.
- Added bare paths to `navigateFallbackDenylist` + `runtimeCaching` (NetworkOnly) and extended `isSafeOAuthNext` to include `/authorize` variants. Also denylisted `/mcp` and `/register` while we were here.

## Test plan
- [x] `pnpm lint`
- [ ] Deploy web, unregister old SW, run MCP Inspector OAuth flow against prod end-to-end

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken OAuth flow for MCP Inspector by supporting bare /authorize, /token, /revoke paths end-to-end and allowing them in login redirects. Also prevents edge buffering on /mcp/sse so MCP tool responses stream immediately.

- **Bug Fixes**
  - Web NGINX: proxy `/authorize`, `/token`, `/revoke` directly to the API.
  - Service worker: denylist and `NetworkOnly` cache rules for the bare OAuth paths; also denylist `/mcp` and `/register`.
  - Login: allow `/authorize` as a safe `next` target to return users to consent.
  - API + NGINX: disable buffering and caching for `/mcp/sse` (SSE) and extend timeouts to keep streams live and flush responses immediately.

- **Migration**
  - After deploy, reload the app or unregister the old service worker to pick up the new SW.

<sup>Written for commit 3e9fd0aceed8a6d172a47d66f9e43a53896e1555. Summary will update on new commits. <a href="https://cubic.dev/pr/briefy-ai/briefy/pull/136?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

