### PR TITLE
SW: skipWaiting + clientsClaim

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -51,6 +51,8 @@ export default defineConfig(({ mode }) => {
         ],
       },
       workbox: {
+        clientsClaim: true,
+        skipWaiting: true,
         navigateFallback: '/index.html',
         navigateFallbackDenylist: [
           /^\/api/,


### PR DESCRIPTION
Without these, updated service workers don't activate until all tabs are closed. This means SW fixes don't reach users on reload — they have to manually unregister.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable immediate service worker activation by setting `workbox.skipWaiting` and `workbox.clientsClaim` in `apps/web/vite.config.ts`. New SW versions now take control on the next reload, so fixes ship without users closing tabs or unregistering.

<sup>Written for commit 63754b1b5366f2b820c703ab9d73becbfb09be15. Summary will update on new commits. <a href="https://cubic.dev/pr/briefy-ai/briefy/pull/137?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

