### PR TITLE
fix(mcp): bump pgvector ivfflat probes for similarity searches

### DIFF
--- a/apps/api/src/main/kotlin/com/briefy/api/infrastructure/enrichment/SourceEmbeddingJdbcRepository.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/infrastructure/enrichment/SourceEmbeddingJdbcRepository.kt
@@ -5,6 +5,7 @@ import com.briefy.api.domain.knowledgegraph.source.SourceSimilarityMatch
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 import java.sql.Timestamp
 import java.time.Instant
 import java.util.UUID
@@ -35,6 +36,7 @@ class SourceEmbeddingJdbcRepository(
         jdbcTemplate.update(sql, params)
     }
 
+    @Transactional(readOnly = true)
     override fun findSimilar(
         userId: UUID,
         queryEmbedding: List<Double>,
@@ -44,6 +46,8 @@ class SourceEmbeddingJdbcRepository(
         if (limit <= 0) {
             return emptyList()
         }
+
+        tunePgvectorProbes()
 
         val sql = buildString {
             appendLine("""
@@ -87,6 +91,7 @@ class SourceEmbeddingJdbcRepository(
         }
     }
 
+    @Transactional(readOnly = true)
     override fun findSimilarBySourceId(
         userId: UUID,
         sourceId: UUID,
@@ -96,6 +101,8 @@ class SourceEmbeddingJdbcRepository(
         if (limit <= 0) {
             return emptyList()
         }
+
+        tunePgvectorProbes()
 
         val sql = buildString {
             appendLine("""
@@ -141,6 +148,7 @@ class SourceEmbeddingJdbcRepository(
         }
     }
 
+    @Transactional(readOnly = true)
     override fun findSimilarRestrictedToSources(
         userId: UUID,
         queryEmbedding: List<Double>,
@@ -150,6 +158,8 @@ class SourceEmbeddingJdbcRepository(
         if (limit <= 0 || allowedSourceIds.isEmpty()) {
             return emptyList()
         }
+
+        tunePgvectorProbes()
 
         val sql = """
             SELECT
@@ -183,6 +193,17 @@ class SourceEmbeddingJdbcRepository(
                 wordCount = rs.getInt("content_word_count")
             )
         }
+    }
+
+    /**
+     * The ivfflat index on `source_embeddings` uses lists=100. With the default
+     * probes=1, similarity searches scan a single inverted list, which often
+     * holds zero rows matching the user_id + status WHERE clause — yielding
+     * empty results despite plenty of valid candidates. probes=10 (≈ √lists)
+     * is the recommended baseline for acceptable recall on this list count.
+     */
+    private fun tunePgvectorProbes() {
+        jdbcTemplate.jdbcTemplate.execute("SET LOCAL ivfflat.probes = 10")
     }
 
     private fun toVectorLiteral(values: List<Double>): String {

--- a/apps/api/src/main/kotlin/com/briefy/api/infrastructure/mcp/tools/SearchSourcesTool.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/infrastructure/mcp/tools/SearchSourcesTool.kt
@@ -6,7 +6,6 @@ import com.briefy.api.domain.knowledgegraph.topiclink.TopicLinkRepository
 import com.briefy.api.infrastructure.ai.EmbeddingAdapter
 import com.briefy.api.infrastructure.mcp.CurrentMcpUser
 import com.briefy.api.infrastructure.mcp.McpJson
-import org.slf4j.LoggerFactory
 import org.springframework.ai.tool.ToolCallback
 import org.springframework.ai.tool.function.FunctionToolCallback
 import org.springframework.stereotype.Component
@@ -22,7 +21,6 @@ class SearchSourcesTool(
     private val topicLinkRepository: TopicLinkRepository,
     private val mcpJson: McpJson,
 ) {
-    private val log = LoggerFactory.getLogger(SearchSourcesTool::class.java)
 
     data class Input(val query: String, val topicId: String? = null, val limit: Int? = null)
 
@@ -69,17 +67,10 @@ class SearchSourcesTool(
             sourceEmbeddingRepository.findSimilar(userId, embedding, limit)
         }
 
-        if (matches.isEmpty()) {
-            log.info("[mcp.search_sources] userId={} limit={} matches=0", userId, limit)
-            return mcpJson.stringify(emptyList<Item>())
-        }
+        if (matches.isEmpty()) return mcpJson.stringify(emptyList<Item>())
 
         val ids = matches.map { it.sourceId }
         val sourcesById = sourceRepository.findAllByUserIdAndIdIn(userId, ids).associateBy { it.id }
-        log.info(
-            "[mcp.search_sources] userId={} limit={} matches={} hydrated={} ids={}",
-            userId, limit, matches.size, sourcesById.size, ids
-        )
         val topicNamesBySource = topicLinkRepository.findActiveTopicsBySourceIds(userId, ids)
             .groupBy({ it.sourceId }, { it.topicName })
 
@@ -101,3 +92,4 @@ class SearchSourcesTool(
         return mcpJson.stringify(items)
     }
 }
+

--- a/apps/api/src/main/kotlin/com/briefy/api/infrastructure/mcp/tools/SearchSourcesTool.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/infrastructure/mcp/tools/SearchSourcesTool.kt
@@ -6,6 +6,7 @@ import com.briefy.api.domain.knowledgegraph.topiclink.TopicLinkRepository
 import com.briefy.api.infrastructure.ai.EmbeddingAdapter
 import com.briefy.api.infrastructure.mcp.CurrentMcpUser
 import com.briefy.api.infrastructure.mcp.McpJson
+import org.slf4j.LoggerFactory
 import org.springframework.ai.tool.ToolCallback
 import org.springframework.ai.tool.function.FunctionToolCallback
 import org.springframework.stereotype.Component
@@ -21,6 +22,8 @@ class SearchSourcesTool(
     private val topicLinkRepository: TopicLinkRepository,
     private val mcpJson: McpJson,
 ) {
+    private val log = LoggerFactory.getLogger(SearchSourcesTool::class.java)
+
     data class Input(val query: String, val topicId: String? = null, val limit: Int? = null)
 
     data class Item(
@@ -66,10 +69,17 @@ class SearchSourcesTool(
             sourceEmbeddingRepository.findSimilar(userId, embedding, limit)
         }
 
-        if (matches.isEmpty()) return mcpJson.stringify(emptyList<Item>())
+        if (matches.isEmpty()) {
+            log.info("[mcp.search_sources] userId={} limit={} matches=0", userId, limit)
+            return mcpJson.stringify(emptyList<Item>())
+        }
 
         val ids = matches.map { it.sourceId }
         val sourcesById = sourceRepository.findAllByUserIdAndIdIn(userId, ids).associateBy { it.id }
+        log.info(
+            "[mcp.search_sources] userId={} limit={} matches={} hydrated={} ids={}",
+            userId, limit, matches.size, sourcesById.size, ids
+        )
         val topicNamesBySource = topicLinkRepository.findActiveTopicsBySourceIds(userId, ids)
             .groupBy({ it.sourceId }, { it.topicName })
 


### PR DESCRIPTION
## Summary
- `source_embeddings` has an ivfflat index with `lists=100`. Postgres defaults `ivfflat.probes=1`, so each similarity query scans **a single inverted list**. After the user_id + status filter, that list usually holds zero rows, so `search_sources` and `search_related` would return `[]` for queries that obviously had hits (e.g. \"gold\", \"ai agents\").
- Wrap each `findSimilar*` JDBC call in a `@Transactional(readOnly = true)` block and issue `SET LOCAL ivfflat.probes = 10` (≈ √lists, the recommended baseline) before the query. Recall now matches manual SQL.

## Test plan
- [x] Verified end-to-end via MCP Inspector against prod: `search_sources(\"gold\")` and `search_sources(\"ai agents\")` both return real source matches at default limit (=5).
- [x] Locally compiled clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase `ivfflat.probes` to 10 for pgvector similarity searches to fix empty results caused by scanning a single list. `search_sources` and related queries now return expected matches.

- **Bug Fixes**
  - Wrap all `findSimilar*` JDBC methods in `@Transactional(readOnly = true)` and run `SET LOCAL ivfflat.probes = 10` before each query.
  - Applies to the `source_embeddings` `ivfflat` index with `lists=100`; `probes=1` often yielded zero rows after `user_id` + `status` filters.
  - Verified end-to-end: queries like "gold" and "ai agents" return matches at the default limit.

<sup>Written for commit f71e4f397afd8fa22a804d93934478acb9cebf68. Summary will update on new commits. <a href="https://cubic.dev/pr/briefy-ai/briefy/pull/138?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

