### PR TITLE
fix: allow concurrent refresh sessions across devices

### DIFF
--- a/apps/api/src/main/kotlin/com/briefy/api/application/auth/AuthService.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/application/auth/AuthService.kt
@@ -156,11 +156,6 @@ class AuthService(
 
     private fun issueTokens(user: User): AuthResult {
         val now = Instant.now()
-        val revokedCount = refreshSessionRepository.revokeActiveByUserId(user.id, now)
-        if (revokedCount > 0) {
-            logger.info("[service] Revoked {} active refresh session(s) on login userId={}", revokedCount, user.id)
-        }
-
         val refreshToken = generateOpaqueToken()
         val refreshSession = RefreshSession(
             id = idGenerator.newId(),

--- a/apps/api/src/main/kotlin/com/briefy/api/domain/identity/session/RefreshSessionRepository.kt
+++ b/apps/api/src/main/kotlin/com/briefy/api/domain/identity/session/RefreshSessionRepository.kt
@@ -1,28 +1,11 @@
 package com.briefy.api.domain.identity.session
 
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Modifying
-import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
-import java.time.Instant
 import java.util.UUID
 
 @Repository
 interface RefreshSessionRepository : JpaRepository<RefreshSession, UUID> {
     fun findByTokenHashAndRevokedAtIsNull(tokenHash: String): RefreshSession?
     fun findByTokenHash(tokenHash: String): RefreshSession?
-
-    @Modifying
-    @Query(
-        """
-        update RefreshSession s
-        set s.revokedAt = :revokedAt
-        where s.userId = :userId and s.revokedAt is null
-        """
-    )
-    fun revokeActiveByUserId(
-        @Param("userId") userId: UUID,
-        @Param("revokedAt") revokedAt: Instant
-    ): Int
 }

--- a/apps/api/src/test/kotlin/com/briefy/api/api/AuthControllerTest.kt
+++ b/apps/api/src/test/kotlin/com/briefy/api/api/AuthControllerTest.kt
@@ -100,6 +100,35 @@ class AuthControllerTest {
     }
 
     @Test
+    fun `second login does not revoke first session's refresh token`() {
+        val email = "concurrent@example.com"
+        val first = signUp(email)
+
+        val secondLogin = mockMvc.perform(
+            post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"email":"$email","password":"password123"}""")
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+
+        val secondCookies = secondLogin.response.getHeaders("Set-Cookie")
+        val secondRefresh = parseCookie(secondCookies, "briefy_refresh_token")
+
+        mockMvc.perform(
+            post("/api/auth/refresh")
+                .cookie(first.refreshCookie)
+        )
+            .andExpect(status().isOk)
+
+        mockMvc.perform(
+            post("/api/auth/refresh")
+                .cookie(secondRefresh)
+        )
+            .andExpect(status().isOk)
+    }
+
+    @Test
     fun `protected routes return 401 without auth`() {
         mockMvc.perform(get("/api/sources"))
             .andExpect(status().isUnauthorized)


### PR DESCRIPTION
## Summary
- Users were being silently logged out a few times a day. Root cause: every login revoked **all** other active refresh sessions for that user, so any other tab/device holding a still-valid refresh cookie would 401 on its next `/api/auth/refresh` and bounce to the login screen.
- Confirmed in Railway logs (today, 2026-05-10): a refresh hit a session created on 04-29 that had been revoked on 05-04 — followed 3s later by a fresh login that itself revoked another active session.
- Fix: drop the revoke-on-login call in `AuthService.issueTokens` so concurrent sessions can coexist (standard web app behavior).

## Test plan
- [x] `./gradlew test` passes
- [ ] Manual: log in on browser A, log in on browser B, confirm A keeps working past its access-token TTL (refresh succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow concurrent refresh sessions across devices by removing the revoke-on-login logic in `AuthService.issueTokens`. This prevents unexpected logouts when the same user logs in from another tab or device.

- **Bug Fixes**
  - Stop revoking other active refresh sessions on login; remove unused `RefreshSessionRepository.revokeActiveByUserId`.
  - Add a regression test proving concurrent logins keep both refresh cookies valid, avoiding 401s on `/api/auth/refresh`.

<sup>Written for commit 41c7c83728fb10f01446f089f6dbd965900ee385. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

