### PR TITLE
feat(web): PWA update + install prompt

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@fontsource-variable/sora": "^5.2.8",
+    "@phosphor-icons/react": "2.1.10",
     "@tanstack/react-router": "^1.158.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@fontsource-variable/sora':
         specifier: ^5.2.8
         version: 5.2.8
+      '@phosphor-icons/react':
+        specifier: 2.1.10
+        version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-router':
         specifier: ^1.158.0
         version: 1.158.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -905,6 +908,13 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@phosphor-icons/react@2.1.10':
+    resolution: {integrity: sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>= 16.8'
+      react-dom: '>= 16.8'
+
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
 
@@ -1681,66 +1691,79 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -1813,24 +1836,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -2970,24 +2997,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -4863,6 +4894,11 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   '@radix-ui/number@1.1.1': {}
 

--- a/apps/web/src/components/pwa/pwa-prompt.tsx
+++ b/apps/web/src/components/pwa/pwa-prompt.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useState, type ReactNode } from 'react'
+import { useRegisterSW } from 'virtual:pwa-register/react'
+import { ArrowClockwise, DownloadSimple, X } from '@phosphor-icons/react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+const APP_NAME = 'Briefy'
+const INSTALL_DISMISSED_KEY = 'briefy.pwa.installDismissed'
+
+interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: ReadonlyArray<string>
+  readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>
+  prompt(): Promise<void>
+}
+
+export function PWAPrompt() {
+  const {
+    needRefresh: [needRefresh, setNeedRefresh],
+    updateServiceWorker,
+  } = useRegisterSW()
+
+  const [updateDismissed, setUpdateDismissed] = useState(false)
+  const [installEvent, setInstallEvent] = useState<BeforeInstallPromptEvent | null>(null)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const dismissed = window.localStorage.getItem(INSTALL_DISMISSED_KEY) === '1'
+
+    const onBeforeInstall = (event: Event) => {
+      event.preventDefault()
+      if (dismissed) return
+      setInstallEvent(event as BeforeInstallPromptEvent)
+    }
+
+    const onInstalled = () => {
+      setInstallEvent(null)
+      window.localStorage.removeItem(INSTALL_DISMISSED_KEY)
+    }
+
+    window.addEventListener('beforeinstallprompt', onBeforeInstall)
+    window.addEventListener('appinstalled', onInstalled)
+    return () => {
+      window.removeEventListener('beforeinstallprompt', onBeforeInstall)
+      window.removeEventListener('appinstalled', onInstalled)
+    }
+  }, [])
+
+  const showUpdate = needRefresh && !updateDismissed
+  const showInstall = Boolean(installEvent)
+
+  if (!showUpdate && !showInstall) return null
+
+  const handleInstall = async () => {
+    if (!installEvent) return
+    await installEvent.prompt()
+    const { outcome } = await installEvent.userChoice
+    if (outcome === 'accepted') {
+      window.localStorage.removeItem(INSTALL_DISMISSED_KEY)
+    }
+    setInstallEvent(null)
+  }
+
+  const handleInstallDismiss = () => {
+    window.localStorage.setItem(INSTALL_DISMISSED_KEY, '1')
+    setInstallEvent(null)
+  }
+
+  return (
+    <div
+      className="pointer-events-none fixed inset-x-0 z-50 flex flex-col items-center gap-3 px-4"
+      style={{ bottom: 'calc(env(safe-area-inset-bottom, 0px) + 4.5rem)' }}
+    >
+      {showUpdate && (
+        <PromptCard
+          icon={<ArrowClockwise weight="bold" className="size-5" />}
+          title="Update available"
+          description="A new version of Briefy is ready. Reload to get the latest."
+          actionLabel="Reload"
+          onAction={() => updateServiceWorker(true)}
+          onDismiss={() => {
+            setUpdateDismissed(true)
+            setNeedRefresh(false)
+          }}
+        />
+      )}
+      {showInstall && (
+        <PromptCard
+          icon={<DownloadSimple weight="bold" className="size-5" />}
+          title={`Install ${APP_NAME}`}
+          description="Add Briefy to your home screen for a faster, app-like experience."
+          actionLabel="Install"
+          onAction={handleInstall}
+          onDismiss={handleInstallDismiss}
+        />
+      )}
+    </div>
+  )
+}
+
+interface PromptCardProps {
+  icon: ReactNode
+  title: string
+  description: string
+  actionLabel: string
+  onAction: () => void
+  onDismiss: () => void
+}
+
+function PromptCard({ icon, title, description, actionLabel, onAction, onDismiss }: PromptCardProps) {
+  return (
+    <div
+      className={cn(
+        'pointer-events-auto flex w-[min(92vw,28rem)] items-start gap-3 rounded-xl border border-border/60',
+        'bg-background/95 p-4 shadow-lg backdrop-blur-md',
+      )}
+      role="dialog"
+      aria-label={title}
+    >
+      <div className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/15 text-primary">
+        {icon}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold text-foreground">{title}</p>
+        <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
+        <div className="mt-3">
+          <Button size="xs" onClick={onAction}>
+            {actionLabel}
+          </Button>
+        </div>
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        className="-mr-1 -mt-1 text-muted-foreground hover:text-foreground"
+      >
+        <X weight="bold" className="size-4" />
+      </Button>
+    </div>
+  )
+}

--- a/apps/web/src/components/pwa/pwa-prompt.tsx
+++ b/apps/web/src/components/pwa/pwa-prompt.tsx
@@ -25,11 +25,9 @@ export function PWAPrompt() {
   useEffect(() => {
     if (typeof window === 'undefined') return
 
-    const dismissed = window.localStorage.getItem(INSTALL_DISMISSED_KEY) === '1'
-
     const onBeforeInstall = (event: Event) => {
       event.preventDefault()
-      if (dismissed) return
+      if (window.localStorage.getItem(INSTALL_DISMISSED_KEY) === '1') return
       setInstallEvent(event as BeforeInstallPromptEvent)
     }
 
@@ -53,12 +51,17 @@ export function PWAPrompt() {
 
   const handleInstall = async () => {
     if (!installEvent) return
-    await installEvent.prompt()
-    const { outcome } = await installEvent.userChoice
-    if (outcome === 'accepted') {
-      window.localStorage.removeItem(INSTALL_DISMISSED_KEY)
+    try {
+      await installEvent.prompt()
+      const { outcome } = await installEvent.userChoice
+      if (outcome === 'accepted') {
+        window.localStorage.removeItem(INSTALL_DISMISSED_KEY)
+      }
+    } catch {
+      // prompt() can throw if the event is stale or already consumed
+    } finally {
+      setInstallEvent(null)
     }
-    setInstallEvent(null)
   }
 
   const handleInstallDismiss = () => {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -5,7 +5,6 @@ import { createRoot } from 'react-dom/client'
 import { RouterProvider, createRouter } from '@tanstack/react-router'
 import { routeTree } from './routeTree.gen'
 import { AuthProvider } from './lib/auth/AuthContext'
-import { registerServiceWorker } from './pwa/registerServiceWorker'
 import './index.css'
 
 const router = createRouter({ routeTree })
@@ -15,8 +14,6 @@ declare module '@tanstack/react-router' {
     router: typeof router
   }
 }
-
-registerServiceWorker()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/apps/web/src/pwa/registerServiceWorker.ts
+++ b/apps/web/src/pwa/registerServiceWorker.ts
@@ -1,9 +1,0 @@
-import { registerSW } from 'virtual:pwa-register'
-
-export function registerServiceWorker() {
-  if (!import.meta.env.PROD) {
-    return
-  }
-
-  registerSW({ immediate: true })
-}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -23,6 +23,7 @@ import {
 import { ChatEngineProvider } from '@/features/chat/ChatEngineProvider'
 import { ChatPanelProvider, useChatPanel } from '@/features/chat/ChatPanelProvider'
 import { AudioPlayerProvider, useHasAudioPlayer } from '@/features/audio/AudioPlayerProvider'
+import { PWAPrompt } from '@/components/pwa/pwa-prompt'
 import { cn } from '@/lib/utils'
 import { useAuth } from '@/lib/auth/useAuth'
 
@@ -189,6 +190,7 @@ function RootLayoutContent() {
           <ChatLauncherButton onClick={openPanelWithDefaultContext} />
         </>
       )}
+      <PWAPrompt />
       <TanStackRouterDevtools />
     </div>
   )

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig(({ mode }) => {
     react(),
     tailwindcss(),
     VitePWA({
-      registerType: 'autoUpdate',
+      registerType: 'prompt',
       injectRegister: false,
       includeAssets: [
         'pwa/apple-touch-icon.png',
@@ -51,8 +51,6 @@ export default defineConfig(({ mode }) => {
         ],
       },
       workbox: {
-        clientsClaim: true,
-        skipWaiting: true,
         navigateFallback: '/index.html',
         navigateFallbackDenylist: [
           /^\/api/,


### PR DESCRIPTION
## Summary
- Switch `vite-plugin-pwa` to `registerType: 'prompt'` (and drop `skipWaiting`/`clientsClaim`) so SW updates require explicit user consent — reverses the auto-update behavior from #137.
- Add `<PWAPrompt />` (single file at `apps/web/src/components/pwa/pwa-prompt.tsx`) rendering two stackable bottom-center toast cards: "Update available" (Reload → `updateServiceWorker(true)`) and "Install Briefy" (native `beforeinstallprompt`). Install dismissal persists in `localStorage` under `briefy.pwa.installDismissed`; cleared on `appinstalled`. Update dismissal is session-only.
- Replace the manual `registerSW()` call in `main.tsx` with `useRegisterSW` from `virtual:pwa-register/react` inside the component; delete the now-unused `src/pwa/registerServiceWorker.ts`.
- Add `@phosphor-icons/react` and use `ArrowClockwise`, `DownloadSimple`, `X`. Styling uses existing design tokens (`bg-background`, `border-border`, `text-muted-foreground`, `bg-primary/15`, etc.) with safe-area inset bottom positioning.

## Test plan
- [ ] `pnpm build` and `pnpm lint` pass (verified locally).
- [ ] Deploy a new SW version → "Update available" card appears; Reload triggers `updateServiceWorker(true)` and refreshes.
- [ ] On a Chromium browser meeting install criteria, `beforeinstallprompt` fires → "Install Briefy" card appears; Install triggers native prompt; Dismiss persists across reloads.
- [ ] After install, `appinstalled` clears the dismissed flag and hides the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds in‑app prompts for PWA updates and install. Service worker updates now wait for user consent instead of auto‑applying.

- **New Features**
  - Switch `vite-plugin-pwa` to `registerType: 'prompt'`; drop `skipWaiting`/`clientsClaim` so updates apply only after a user reload.
  - Add `<PWAPrompt />` (mounted in `__root`) showing stacked "Update available" and "Install Briefy" toasts via `useRegisterSW` and `beforeinstallprompt`.
  - Persist install dismissal in `localStorage` (`briefy.pwa.installDismissed`, cleared on `appinstalled`); update dismissal is session‑only. Replace manual `registerSW()` and remove `src/pwa/registerServiceWorker.ts`. Use `@phosphor-icons/react` for icons.

- **Bug Fixes**
  - Read the install‑dismissed flag inside the `beforeinstallprompt` handler to ignore repeated events after navigation, and wrap `installEvent.prompt()` in try/finally to prevent a stuck card if the prompt throws.

<sup>Written for commit fac59206e2a9f18fd81b2b127847698d36536f80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

