### PR TITLE
fix(web): approve esbuild build script for pnpm 11

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -50,5 +50,10 @@
     "typescript-eslint": "^8.46.4",
     "vite": "^7.2.4",
     "vite-plugin-pwa": "^1.2.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
Railway's `briefy-web` build started failing on the post-merge deploy of #141 with:

\`\`\`
ERR_PNPM_IGNORED_BUILDS: Ignored build scripts: esbuild@0.27.2
\`\`\`

Railway's image installs pnpm via Corepack and currently pulls **pnpm 11.1.1**, which (unlike pnpm 10) fails `--frozen-lockfile` installs when any dependency has an unapproved postinstall script. The failure surfaced after #141 because adding `@phosphor-icons/react` rewrote the lockfile, but the root cause is the pnpm 11 default — it would have hit us on the next lockfile change regardless.

Fix: whitelist `esbuild` via `pnpm.onlyBuiltDependencies` in `apps/web/package.json` so its postinstall is allowed to run.

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds locally (esbuild postinstall now runs instead of being ignored).
- [ ] Railway `briefy-web` build green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Railway `briefy-web` deploys failing on pnpm 11 by allowing the `esbuild` postinstall during `--frozen-lockfile` installs. Added `pnpm.onlyBuiltDependencies: ["esbuild"]` in `apps/web/package.json` so builds no longer error on ignored scripts.

<sup>Written for commit 3e5e19d59070246e6efb855fa0b714d18fa2d80e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

